### PR TITLE
feat: build dashboard screen with tests (PP-007)

### DIFF
--- a/server/data/promises.json
+++ b/server/data/promises.json
@@ -11,8 +11,27 @@
     "successCriteria": [
       "Success metric TBD"
     ],
-    "stake": {"type": "financial", "amount": 10},
+    "stake": {
+      "type": "financial",
+      "amount": 10
+    },
     "createdAt": "2026-03-09T18:11:17.530Z",
+    "status": "pending"
+  },
+  {
+    "id": "prm_1775837594241_m91n14d76",
+    "promiserId": "dev_user_001",
+    "promiseeScope": "individual",
+    "domain": "Web Dev",
+    "objective": "Build the dashboard screen",
+    "timeline": 30,
+    "successCriteria": "Dashboard renders with real data",
+    "stake": {
+      "type": "reputational",
+      "amount": null,
+      "status": "held"
+    },
+    "createdAt": "2026-04-10T16:13:14.241Z",
     "status": "pending"
   }
 ]

--- a/server/src/cli.js
+++ b/server/src/cli.js
@@ -12,7 +12,6 @@ const {
 // TODO (Tech Debt): Refactor assessment, merit, and ledger logic.
 // 'stake' is now an object { type, amount, currency, status }.
 // Passing this object into recordAssessment, slashStake, or doing math (stake * 2) will cause NaN/type errors.
-
 const createPromise = (
   promiserId,
   promiseeScope = null,
@@ -43,7 +42,7 @@ const listPromises = (filters = {}) => {
   console.log("\n=== Promises ===");
   if (promises.length === 0) {
     console.log("No promises found.");
-    return;
+    return [];
   }
   promises.forEach((p) => {
     const summary = getAssessmentSummary(p.id);
@@ -51,6 +50,7 @@ const listPromises = (filters = {}) => {
       `Promise ${p.id} | ${summary.kept} KEPT, ${summary.broken} BROKEN`,
     );
   });
+  return promises;
 };
 
 const submitAssessment = (
@@ -97,7 +97,7 @@ const listAssessments = (filters = {}) => {
   console.log("\n=== Assessments ===");
   if (assessments.length === 0) {
     console.log("No assessments found.");
-    return;
+    return [];
   }
   assessments.forEach((a) => {
     const assessorId = a.assessorId || "Unknown";
@@ -109,6 +109,7 @@ const listAssessments = (filters = {}) => {
       `${a.id} | PromiseID: ${a.promiseId} | Assessor: ${assessorId} | Verdict: ${a.judgment} | Stake: ${stake} | Date: ${date}`,
     );
   });
+  return assessments;
 };
 
 module.exports = {

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,19 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  height: 100%;
+  width: 100%;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+body {
+  font-family: 'DM Sans', 'Helvetica Neue', sans-serif;
+  background: #09090c;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,7 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import Dashboard from './pages/Dashboard';
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <Dashboard />;
 }
 
-export default App
+export default App;

--- a/src/components/RecentPromiseCard.jsx
+++ b/src/components/RecentPromiseCard.jsx
@@ -1,0 +1,38 @@
+import styles from './RecentPromiseCard.module.css';
+
+const STATUS = {
+  pending: { label: 'Active', color: '#4FC3F7', bg: 'rgba(79,195,247,0.10)' },
+  KEPT: { label: 'Kept', color: '#4CAF82', bg: 'rgba(76,175,130,0.10)' },
+  BROKEN: { label: 'Broken', color: '#E05252', bg: 'rgba(224,82,82,0.10)' },
+};
+
+export default function RecentPromiseCard({ promise }) {
+  const status = promise.status || 'pending';
+  const cfg = STATUS[status] || STATUS.pending;
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.statusBar} style={{ background: cfg.color }} />
+      <div className={styles.content}>
+        <div className={styles.cardHeader}>
+          <span className={styles.domain}>{promise.domain}</span>
+          <span
+            className={styles.badge}
+            style={{ color: cfg.color, background: cfg.bg }}
+          >
+            {cfg.label}
+          </span>
+        </div>
+        <div className={styles.objective}>{promise.objective}</div>
+        <span className={styles.stakeChip}>
+          <span className={styles.stakeIcon}>
+            {promise.stake.type === 'financial' ? '$' : '◎'}
+          </span>
+          {promise.stake.type === 'financial'
+            ? `$${promise.stake.amount} deposited`
+            : 'Reputation deposited'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecentPromiseCard.module.css
+++ b/src/components/RecentPromiseCard.module.css
@@ -1,0 +1,59 @@
+.card {
+  display: flex;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.statusBar {
+  width: 3px;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.content {
+  flex: 1;
+  padding: 16px 22px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.domain {
+  font-size: 12px;
+  color: #4fc3f7;
+  font-weight: 600;
+}
+
+.objective {
+  font-size: 13px;
+  color: #e8e8ec;
+  margin-bottom: 10px;
+}
+
+.badge {
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.stakeChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: #888;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 4px 10px;
+  border-radius: 6px;
+}
+
+.stakeIcon {
+  color: #4fc3f7;
+  font-weight: 700;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,22 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  font-family: 'DM Sans', 'Helvetica Neue', sans-serif;
+  background: #09090c;
+  color: #e8e8ec;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,128 @@
+import { useState, useEffect } from 'react';
+import { getPromises, getAssessments } from '../services/api';
+import RecentPromiseCard from '../components/RecentPromiseCard';
+import styles from './Dashboard.module.css';
+
+export default function Dashboard() {
+  const [promises, setPromises] = useState([]);
+  const [assessments, setAssessments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const [promisesData, assessmentsData] = await Promise.all([
+          getPromises(),
+          getAssessments(),
+        ]);
+        setPromises(promisesData);
+        setAssessments(assessmentsData);
+      } catch (err) {
+        setError('Failed to load dashboard data. Please try again.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  const keptCount = assessments.filter((a) => a.judgment === 'KEPT').length;
+  const brokenCount = assessments.filter((a) => a.judgment === 'BROKEN').length;
+  const totalCount = promises.length;
+  const recent = [...promises]
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+    .slice(0, 3);
+
+  if (loading) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.mutedText}>Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.errorText}>{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      {/* Header */}
+      <div className={styles.header}>
+        <div>
+          <h1 className={styles.heading}>Good morning, Jordan.</h1>
+          <p className={styles.subheading}>Here's your commitment activity.</p>
+        </div>
+        <button
+          className={styles.newPromiseButton}
+          onClick={() =>
+            console.log('Navigate to Create Promise — wired in Epic 3')
+          }
+        >
+          + New Commitment
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className={styles.statsGrid}>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>REP SCORE</div>
+          <div className={`${styles.statValue} ${styles.statValueDefault}`}>
+            --
+          </div>
+          <div className={styles.statSub}>Pending algorithm</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>TOTAL MADE</div>
+          <div className={`${styles.statValue} ${styles.statValueDefault}`}>
+            {totalCount}
+          </div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>KEPT</div>
+          <div className={`${styles.statValue} ${styles.statValueGreen}`}>
+            {keptCount}
+          </div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>BROKEN</div>
+          <div className={`${styles.statValue} ${styles.statValueRed}`}>
+            {brokenCount}
+          </div>
+        </div>
+      </div>
+
+      {/* Recent Promises */}
+      <div className={styles.recentCard}>
+        <div className={styles.recentHeader}>
+          <span className={styles.recentTitle}>Recent Commitments</span>
+          <button
+            className={styles.viewAll}
+            onClick={() =>
+              console.log('Navigate to My Promises — wired in Epic 3')
+            }
+          >
+            View all →
+          </button>
+        </div>
+
+        {promises.length === 0 ? (
+          <div className={styles.emptyState}>
+            <p className={styles.mutedText}>
+              No commitments yet. Create your first one!
+            </p>
+          </div>
+        ) : (
+          recent.map((promise) => (
+            <RecentPromiseCard key={promise.id} promise={promise} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,6 +3,8 @@ import { getPromises, getAssessments } from '../services/api';
 import RecentPromiseCard from '../components/RecentPromiseCard';
 import styles from './Dashboard.module.css';
 
+const CURRENT_USER = 'dev_user_001'; // Epic 4 Auth stub
+
 export default function Dashboard() {
   const [promises, setPromises] = useState([]);
   const [assessments, setAssessments] = useState([]);
@@ -12,12 +14,24 @@ export default function Dashboard() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const [promisesData, assessmentsData] = await Promise.all([
+        const [allPromises, allAssessments] = await Promise.all([
           getPromises(),
           getAssessments(),
         ]);
-        setPromises(promisesData);
-        setAssessments(assessmentsData);
+
+        // Filter to current user's promises only
+        const myPromises = allPromises.filter(
+          (p) => p.promiserId === CURRENT_USER
+        );
+        const myPromiseIds = myPromises.map((p) => p.id);
+
+        // Filter assessments to only those against the current user's promises
+        const myAssessments = allAssessments.filter((a) =>
+          myPromiseIds.includes(a.promiseId)
+        );
+
+        setPromises(myPromises);
+        setAssessments(myAssessments);
       } catch (err) {
         setError('Failed to load dashboard data. Please try again.');
       } finally {
@@ -30,9 +44,21 @@ export default function Dashboard() {
   const keptCount = assessments.filter((a) => a.judgment === 'KEPT').length;
   const brokenCount = assessments.filter((a) => a.judgment === 'BROKEN').length;
   const totalCount = promises.length;
+
   const recent = [...promises]
     .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
     .slice(0, 3);
+
+  // Derive status from assessments for each recent promise
+  const recentWithDerivedStatus = recent.map((promise) => {
+    const linkedAssessment = assessments.find(
+      (a) => a.promiseId === promise.id
+    );
+    return {
+      ...promise,
+      status: linkedAssessment ? linkedAssessment.judgment : promise.status,
+    };
+  });
 
   if (loading) {
     return (
@@ -118,7 +144,7 @@ export default function Dashboard() {
             </p>
           </div>
         ) : (
-          recent.map((promise) => (
+          recentWithDerivedStatus.map((promise) => (
             <RecentPromiseCard key={promise.id} promise={promise} />
           ))
         )}

--- a/src/pages/Dashboard.module.css
+++ b/src/pages/Dashboard.module.css
@@ -1,0 +1,144 @@
+.container {
+  padding: 40px 48px;
+  flex: 1;
+  overflow-y: auto;
+  height: 100vh;
+  background: #09090c;
+  color: #e8e8ec;
+  font-family: 'DM Sans', 'Helvetica Neue', sans-serif;
+}
+
+.centered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #09090c;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 40px;
+}
+
+.heading {
+  font-size: 26px;
+  font-weight: 800;
+  color: #e8e8ec;
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.subheading {
+  font-size: 14px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.newPromiseButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background: #4fc3f7;
+  color: #09090c;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 800;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 36px;
+}
+
+.statCard {
+  background: #111116;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 22px 24px;
+}
+
+.statLabel {
+  font-size: 10px;
+  color: #444;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 14px;
+}
+
+.statValue {
+  font-size: 40px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.statValueDefault {
+  color: #e8e8ec;
+}
+.statValueGreen {
+  color: #4caf82;
+}
+.statValueRed {
+  color: #e05252;
+}
+
+.statSub {
+  font-size: 11px;
+  color: #888;
+}
+
+.recentCard {
+  background: #111116;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.recentHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.recentTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: #e8e8ec;
+}
+
+.viewAll {
+  font-size: 12px;
+  color: #4fc3f7;
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-family: inherit;
+  padding: 0;
+}
+
+.emptyState {
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.mutedText {
+  color: #444;
+  font-size: 13px;
+}
+
+.errorText {
+  color: #e05252;
+  font-size: 13px;
+}

--- a/src/pages/Dashboard.test.jsx
+++ b/src/pages/Dashboard.test.jsx
@@ -1,0 +1,142 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import Dashboard from './Dashboard';
+
+vi.mock('../services/api', () => ({
+  getPromises: vi.fn(),
+  getAssessments: vi.fn(),
+}));
+
+import { getPromises, getAssessments } from '../services/api';
+
+const mockPromises = [
+  {
+    id: 'prm_001',
+    promiserId: 'dev_user_001',
+    promiseeScope: 'individual',
+    domain: 'Web Dev',
+    objective: 'Build the dashboard screen',
+    timeline: 30,
+    successCriteria: 'Dashboard renders with real data',
+    stake: { type: 'reputational', amount: null, status: 'held' },
+    status: 'pending',
+    createdAt: '2026-04-01T00:00:00.000Z',
+  },
+  {
+    id: 'prm_002',
+    promiserId: 'dev_user_001',
+    promiseeScope: 'individual',
+    domain: 'Design',
+    objective: 'Create logo',
+    timeline: 14,
+    successCriteria: 'Logo delivered',
+    stake: { type: 'financial', amount: 100, currency: 'USD', status: 'held' },
+    status: 'pending',
+    createdAt: '2026-04-02T00:00:00.000Z',
+  },
+];
+
+const mockAssessments = [
+  {
+    id: 'asm_001',
+    promiseId: 'prm_001',
+    assessorId: 'dev_user_001',
+    judgment: 'KEPT',
+    evidenceCid: 'QmXyz...',
+    createdAt: '2026-04-03T00:00:00.000Z',
+  },
+  {
+    id: 'asm_002',
+    promiseId: 'prm_002',
+    assessorId: 'dev_user_001',
+    judgment: 'BROKEN',
+    evidenceCid: 'QmAbc...',
+    createdAt: '2026-04-04T00:00:00.000Z',
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Dashboard', () => {
+  test('renders correctly with mocked API data', async () => {
+    getPromises.mockResolvedValue(mockPromises);
+    getAssessments.mockResolvedValue(mockAssessments);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Build the dashboard screen')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Good morning, Jordan.')).toBeInTheDocument();
+    expect(
+      screen.getByText("Here's your commitment activity.")
+    ).toBeInTheDocument();
+  });
+
+  test('displays correct counts for total, kept, and broken', async () => {
+    getPromises.mockResolvedValue(mockPromises);
+    getAssessments.mockResolvedValue(mockAssessments);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    const allOnes = screen.getAllByText('1');
+    expect(allOnes).toHaveLength(2);
+  });
+
+  test('renders empty state when no promises exist', async () => {
+    getPromises.mockResolvedValue([]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No commitments yet. Create your first one!')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('renders error state when API call fails', async () => {
+    getPromises.mockRejectedValue(new Error('Network error'));
+    getAssessments.mockRejectedValue(new Error('Network error'));
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to load dashboard data. Please try again.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('New Commitment button is present', async () => {
+    getPromises.mockResolvedValue(mockPromises);
+    getAssessments.mockResolvedValue(mockAssessments);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('+ New Commitment')).toBeInTheDocument();
+    });
+  });
+
+  test('View all button is present', async () => {
+    getPromises.mockResolvedValue(mockPromises);
+    getAssessments.mockResolvedValue(mockAssessments);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('View all →')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Dashboard.test.jsx
+++ b/src/pages/Dashboard.test.jsx
@@ -34,6 +34,18 @@ const mockPromises = [
     status: 'pending',
     createdAt: '2026-04-02T00:00:00.000Z',
   },
+  {
+    id: 'prm_003',
+    promiserId: 'other_user_999',
+    promiseeScope: 'individual',
+    domain: 'Marketing',
+    objective: 'This belongs to another user',
+    timeline: 7,
+    successCriteria: 'Should not appear',
+    stake: { type: 'reputational', amount: null, status: 'held' },
+    status: 'pending',
+    createdAt: '2026-04-03T00:00:00.000Z',
+  },
 ];
 
 const mockAssessments = [
@@ -78,6 +90,23 @@ describe('Dashboard', () => {
     ).toBeInTheDocument();
   });
 
+  test('only shows promises belonging to the current user', async () => {
+    getPromises.mockResolvedValue(mockPromises);
+    getAssessments.mockResolvedValue(mockAssessments);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Build the dashboard screen')
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText('This belongs to another user')
+    ).not.toBeInTheDocument();
+  });
+
   test('displays correct counts for total, kept, and broken', async () => {
     getPromises.mockResolvedValue(mockPromises);
     getAssessments.mockResolvedValue(mockAssessments);
@@ -90,6 +119,19 @@ describe('Dashboard', () => {
 
     const allOnes = screen.getAllByText('1');
     expect(allOnes).toHaveLength(2);
+  });
+
+  test('derives promise status from linked assessment judgment', async () => {
+    getPromises.mockResolvedValue(mockPromises);
+    getAssessments.mockResolvedValue(mockAssessments);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Kept')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Broken')).toBeInTheDocument();
   });
 
   test('renders empty state when no promises exist', async () => {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Builds the Dashboard screen — the primary landing screen for Promise Protocol. The component fetches real data from GET /api/promises and GET /api/assessments, displays aggregate counts (total made, kept, broken), lists the 3 most recent commitments, and stubs the reputation score pending Bob's algorithm. Also includes a fix to server/src/cli.js where listPromises was not returning data, which caused the API to return an empty array.

## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #
https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/9

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [x] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [x] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

- server/src/cli.js — listPromises was logging to the console but not returning the promise array. Added return promises so the route handler receives real data instead of undefined.

- Navigation buttons ("+ New Commitment" and "View all →") are present in the UI but not wired to routes — routing is scoped to Epic 3.

- Reputation score is intentionally stubbed as -- pending Sponsio algorithm.
- CSS uses CSS Modules per the convention established for Sprint 2.
- A shared component src/components/RecentPromiseCard.jsx was created and is available for reuse by other screens.
