### PR TITLE
feat: build promise detail screen with tests (PP-010)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,9 +7,14 @@
 }
 
 html,
-body,
-#root {
+body {
   height: 100%;
+  width: 100%;
+}
+
+#root {
+  display: flex;
+  min-height: 100%;
   width: 100%;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-import Dashboard from './pages/Dashboard';
+import './App.css';
+import PromiseDetail from './pages/PromiseDetail';
 
 function App() {
-  return <Dashboard />;
+  return <PromiseDetail promiseId="prm_1775837594241_m91n14d76" />;
 }
 
 export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,14 @@
 }
 
 html,
-body,
-#root {
+body {
   height: 100%;
+  width: 100%;
+}
+
+#root {
+  display: flex;
+  min-height: 100%;
   width: 100%;
 }
 

--- a/src/pages/PromiseDetail.jsx
+++ b/src/pages/PromiseDetail.jsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from 'react';
+import { getPromises, getAssessments } from '../services/api';
+import styles from './PromiseDetail.module.css';
+
+// Epic 3 note: replace with useParams() from React Router
+// Epic 3 note: replace promiseId prop with route param
+
+const STATUS = {
+  pending: { label: 'Active', color: '#4FC3F7', bg: 'rgba(79,195,247,0.10)' },
+  KEPT: { label: 'Kept', color: '#4CAF82', bg: 'rgba(76,175,130,0.10)' },
+  BROKEN: { label: 'Broken', color: '#E05252', bg: 'rgba(224,82,82,0.10)' },
+};
+
+export default function PromiseDetail({ promiseId }) {
+  const [promise, setPromise] = useState(null);
+  const [assessments, setAssessments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const [allPromises, allAssessments] = await Promise.all([
+          getPromises(),
+          getAssessments(),
+        ]);
+
+        const matched = allPromises.find((p) => p.id === promiseId);
+
+        if (!matched) {
+          setNotFound(true);
+          return;
+        }
+
+        const linkedAssessments = allAssessments.filter(
+          (a) => a.promiseId === promiseId
+        );
+
+        setPromise(matched);
+        setAssessments(linkedAssessments);
+      } catch (err) {
+        setError('Failed to load promise details. Please try again.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (promiseId) {
+      fetchData();
+    }
+  }, [promiseId]);
+
+  if (loading) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.mutedText}>Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.errorText}>{error}</p>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.notFound}>Promise not found.</p>
+      </div>
+    );
+  }
+
+  const status = promise.status || 'pending';
+  const cfg = STATUS[status] || STATUS.pending;
+
+  const stakeDisplay =
+    promise.stake.type === 'financial'
+      ? `$${promise.stake.amount}`
+      : 'Reputation';
+
+  const timelineDisplay =
+    status === 'pending'
+      ? '--' // Epic 3 stub: days remaining calculation pending clarification
+      : 'Closed';
+
+  const createdAtDisplay = new Date(promise.createdAt).toLocaleDateString(
+    'en-US',
+    { month: 'short', day: 'numeric', year: 'numeric' }
+  );
+
+  return (
+    <div className={styles.container}>
+      {/* Back navigation — Epic 3: replace with useNavigate() */}
+      <button
+        className={styles.backButton}
+        onClick={() =>
+          console.log('Navigate back to My Promises — wired in Epic 3')
+        }
+      >
+        ← Back to Promises
+      </button>
+
+      <div className={styles.content}>
+        {/* Promise Card */}
+        <div className={styles.promiseCard}>
+          <div className={styles.statusBar} style={{ background: cfg.color }} />
+          <div className={styles.promiseCardBody}>
+            <div className={styles.promiseCardHeader}>
+              <div className={styles.domainRow}>
+                <span className={styles.domain}>{promise.domain}</span>
+                <span className={styles.arrow}>→</span>
+                <span className={styles.promisee}>{promise.promiseeScope}</span>
+              </div>
+              <span
+                className={styles.badge}
+                style={{ color: cfg.color, background: cfg.bg }}
+              >
+                {cfg.label}
+              </span>
+            </div>
+
+            <div className={styles.objective}>{promise.objective}</div>
+
+            <div className={styles.metaGrid}>
+              <div className={styles.metaItem}>
+                <div className={styles.metaLabel}>Created</div>
+                <div className={styles.metaValue}>{createdAtDisplay}</div>
+              </div>
+              <div className={styles.metaItem}>
+                <div className={styles.metaLabel}>Timeline</div>
+                <div className={styles.metaValue}>{timelineDisplay}</div>
+              </div>
+              <div className={styles.metaItem}>
+                <div className={styles.metaLabel}>Deposit</div>
+                <div className={styles.metaValue}>{stakeDisplay}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Assessments Card */}
+        <div className={styles.assessmentsCard}>
+          <div className={styles.assessmentsHeader}>Assessments</div>
+          {assessments.length === 0 ? (
+            <div className={styles.emptyAssessments}>
+              No assessments yet. This promise is still active.
+            </div>
+          ) : (
+            assessments.map((a) => {
+              const aCfg = STATUS[a.judgment] || STATUS.pending;
+              const aDate = new Date(a.createdAt).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              });
+              return (
+                <div key={a.id} className={styles.assessmentRow}>
+                  <div>
+                    <div className={styles.assessorName}>{a.assessorId}</div>
+                    <div className={styles.assessmentDate}>{aDate}</div>
+                  </div>
+                  <span
+                    className={styles.badge}
+                    style={{ color: aCfg.color, background: aCfg.bg }}
+                  >
+                    {aCfg.label}
+                  </span>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Submit Assessment CTA — Epic 3: wire navigation to PP-012 */}
+        {status === 'pending' && (
+          <div className={styles.ctaCard}>
+            <div>
+              <div className={styles.ctaTitle}>Ready to assess?</div>
+              <div className={styles.ctaSubtitle}>
+                Submit a verdict when this commitment is fulfilled or broken.
+              </div>
+            </div>
+            <button
+              className={styles.ctaButton}
+              onClick={() =>
+                console.log('Navigate to Submit Assessment — wired in Epic 3')
+              }
+            >
+              Submit Assessment
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PromiseDetail.module.css
+++ b/src/pages/PromiseDetail.module.css
@@ -1,0 +1,223 @@
+.container {
+  padding: 40px 48px;
+  height: 100vh;
+  width: 100%;
+  background: #09090c;
+  color: #e8e8ec;
+  font-family: 'DM Sans', 'Helvetica Neue', sans-serif;
+  overflow-y: auto;
+}
+
+.centered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #09090c;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #888;
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-family: inherit;
+  padding: 0;
+  margin-bottom: 28px;
+}
+
+.backButton:hover {
+  color: #e8e8ec;
+}
+
+.content {
+  max-width: 680px;
+  width: 100%;
+}
+
+.promiseCard {
+  background: #111116;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.statusBar {
+  height: 4px;
+  opacity: 0.8;
+}
+
+.promiseCardBody {
+  padding: 28px 30px;
+}
+
+.promiseCardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.domainRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.domain {
+  font-size: 11px;
+  color: #4fc3f7;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.arrow {
+  color: #444;
+  font-size: 12px;
+}
+
+.promisee {
+  font-size: 12px;
+  color: #888;
+}
+
+.badge {
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.objective {
+  font-size: 20px;
+  font-weight: 700;
+  color: #e8e8ec;
+  line-height: 1.4;
+  margin-bottom: 22px;
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 14px;
+}
+
+.metaItem {
+  background: rgba(255, 255, 255, 0.025);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.metaLabel {
+  font-size: 10px;
+  color: #444;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  margin-bottom: 6px;
+}
+
+.metaValue {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e8e8ec;
+}
+
+.assessmentsCard {
+  background: #111116;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.assessmentsHeader {
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 14px;
+  font-weight: 700;
+  color: #e8e8ec;
+}
+
+.assessmentRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.assessorName {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e8e8ec;
+  margin-bottom: 4px;
+}
+
+.assessmentDate {
+  font-size: 12px;
+  color: #888;
+}
+
+.emptyAssessments {
+  padding: 32px 24px;
+  text-align: center;
+  color: #444;
+  font-size: 13px;
+}
+
+.ctaCard {
+  border-radius: 14px;
+  padding: 22px 26px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(79, 195, 247, 0.1);
+  border: 1px solid rgba(79, 195, 247, 0.25);
+}
+
+.ctaTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: #e8e8ec;
+  margin-bottom: 4px;
+}
+
+.ctaSubtitle {
+  font-size: 12px;
+  color: #888;
+}
+
+.ctaButton {
+  padding: 10px 20px;
+  background: #4fc3f7;
+  color: #09090c;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.mutedText {
+  color: #444;
+  font-size: 13px;
+}
+
+.errorText {
+  color: #e05252;
+  font-size: 13px;
+}
+
+.notFound {
+  font-size: 14px;
+  color: #888;
+}

--- a/src/pages/PromiseDetail.test.jsx
+++ b/src/pages/PromiseDetail.test.jsx
@@ -1,0 +1,149 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import PromiseDetail from './PromiseDetail';
+
+vi.mock('../services/api', () => ({
+  getPromises: vi.fn(),
+  getAssessments: vi.fn(),
+}));
+
+import { getPromises, getAssessments } from '../services/api';
+
+const mockPendingPromise = {
+  id: 'prm_001',
+  promiserId: 'dev_user_001',
+  promiseeScope: 'individual',
+  domain: 'Web Dev',
+  objective: 'Build the dashboard screen',
+  timeline: 30,
+  successCriteria: 'Dashboard renders with real data',
+  stake: { type: 'reputational', amount: null, status: 'held' },
+  status: 'pending',
+  createdAt: '2026-04-01T12:00:00.000Z',
+};
+
+const mockKeptPromise = {
+  ...mockPendingPromise,
+  id: 'prm_002',
+  status: 'KEPT',
+};
+
+const mockAssessment = {
+  id: 'asm_001',
+  promiseId: 'prm_001',
+  assessorId: 'dev_user_001',
+  judgment: 'KEPT',
+  evidenceCid: 'QmXyz...',
+  createdAt: '2026-04-05T12:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PromiseDetail', () => {
+  test('renders all promise fields correctly with mocked data', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<PromiseDetail promiseId="prm_001" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Build the dashboard screen')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Web Dev')).toBeInTheDocument();
+    expect(screen.getByText('individual')).toBeInTheDocument();
+    expect(screen.getByText('Reputation')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  test('Submit Assessment CTA is visible when status is pending', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<PromiseDetail promiseId="prm_001" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Submit Assessment')).toBeInTheDocument();
+    });
+  });
+
+  test('Submit Assessment CTA is hidden when status is KEPT', async () => {
+    getPromises.mockResolvedValue([mockKeptPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<PromiseDetail promiseId="prm_002" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Build the dashboard screen')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Submit Assessment')).not.toBeInTheDocument();
+  });
+
+  test('renders empty assessment state when no assessments exist', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<PromiseDetail promiseId="prm_001" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No assessments yet. This promise is still active.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('lists assessments associated with the promise', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([mockAssessment]);
+
+    render(<PromiseDetail promiseId="prm_001" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('dev_user_001')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Apr 5, 2026')).toBeInTheDocument();
+  });
+
+  test('renders not found state when promiseId does not match any promise', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<PromiseDetail promiseId="prm_999" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Promise not found.')).toBeInTheDocument();
+    });
+  });
+
+  test('renders error state when API call fails', async () => {
+    getPromises.mockRejectedValue(new Error('Network error'));
+    getAssessments.mockRejectedValue(new Error('Network error'));
+
+    render(<PromiseDetail promiseId="prm_001" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to load promise details. Please try again.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('back navigation button is present', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    render(<PromiseDetail promiseId="prm_001" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('← Back to Promises')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Summary

Builds the Promise Detail screen — the full view for a single promise, including all promise fields, assessment history, and a conditional Submit Assessment Call to Action (CTA). The component accepts a promiseId prop, fetches both GET /api/promises and GET /api/assessments, matches the promise by ID, and filters assessments by promiseId client-side. Handles loading, error, and not-found states.

## Related Issue

<!-- Link the backlog item this PR addresses -->

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/12

Closes #

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [x] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->
- promiseId is currently passed as a prop — in Epic 3 this will be replaced with useParams() from React Router
- Back navigation and Submit Assessment CTA are stubbed with console.log — both will be wired to routes in Epic 3
- Timeline display is stubbed as -- pending clarification from Bob on the days-remaining calculation
- Submit Assessment CTA is conditionally rendered — visible when status === "pending", hidden when status is "KEPT" or "BROKEN"
- CSS follows the CSS Modules convention established for Sprint 2
- Layout will appear narrow in isolation — this component is designed to live inside the app shell with sidebar (Epic 3), at which point the full-width layout will be correct
