### PR TITLE
feat: build create promise screen (PP-008)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import './App.css';
-import PromiseDetail from './pages/PromiseDetail';
+import CreatePromise from './pages/CreatePromise';
 
 function App() {
-  return <PromiseDetail promiseId="prm_1775837594241_m91n14d76" />;
+  return <CreatePromise />;
 }
 
 export default App;

--- a/src/pages/CreatePromise.jsx
+++ b/src/pages/CreatePromise.jsx
@@ -1,0 +1,240 @@
+import { useState } from 'react';
+import { createPromise } from '../services/api';
+import styles from './CreatePromise.module.css';
+
+const INITIAL_FORM = {
+  objective: '',
+  promiseeName: '',
+  promiseeScope: '',
+  domain: '',
+  days: '',
+  successCriteria: '',
+  stakeType: 'reputational',
+  stakeAmount: '',
+};
+
+const CURRENT_USER = 'dev_user_001';
+
+export default function CreatePromise() {
+  const [form, setForm] = useState(INITIAL_FORM);
+  const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [submitSuccess, setSubmitSuccess] = useState('');
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === 'stakeType' && value === 'reputational'
+        ? { stakeAmount: '' }
+        : {}),
+    }));
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setSubmitError('');
+  };
+
+  const validate = () => {
+    const nextErrors = {};
+
+    if (!form.objective.trim()) nextErrors.objective = 'Commitment objective is required.';
+    if (!form.promiseeName.trim()) nextErrors.promiseeName = 'Commitment recipient is required.';
+    if (!form.promiseeScope) nextErrors.promiseeScope = 'Commitment scope is required.';
+    if (!form.domain.trim()) nextErrors.domain = 'Domain is required.';
+
+    const daysNumber = Number(form.days);
+    if (!form.days || Number.isNaN(daysNumber) || !Number.isInteger(daysNumber) || daysNumber <= 0) {
+      nextErrors.days = 'Timeline must be a positive whole number of days.';
+    }
+
+    if (!form.successCriteria.trim()) {
+      nextErrors.successCriteria = 'Success criteria is required.';
+    }
+
+    if (form.stakeType === 'financial') {
+      const amountNumber = Number(form.stakeAmount);
+      if (!form.stakeAmount || Number.isNaN(amountNumber) || amountNumber <= 0) {
+        nextErrors.stakeAmount = 'Financial deposit amount must be a positive number.';
+      }
+    }
+
+    return nextErrors;
+  };
+
+  const buildPayload = () => {
+    const payload = {
+      promiserId: CURRENT_USER,
+      promiseeScope: form.promiseeScope,
+      domain: form.domain.trim(),
+      objective: form.objective.trim(),
+      days: Number(form.days),
+      successCriteria: form.successCriteria.trim(),
+      stake: {
+        type: form.stakeType,
+      },
+    };
+
+    if (form.stakeType === 'financial') {
+      payload.stake.amount = Number(form.stakeAmount);
+    }
+
+    return payload;
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const nextErrors = validate();
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError('');
+    setSubmitSuccess('');
+
+    try {
+      await createPromise(buildPayload());
+      setSubmitSuccess('Commitment created successfully.');
+      setErrors({});
+      setForm(INITIAL_FORM);
+    } catch {
+      setSubmitError('Failed to create commitment. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.card}>
+        <h1 className={styles.heading}>Create Commitment</h1>
+        <p className={styles.subheading}>Record your commitment details below.</p>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <label htmlFor="objective">Commitment objective</label>
+          <input
+            id="objective"
+            name="objective"
+            value={form.objective}
+            onChange={handleChange}
+            aria-invalid={Boolean(errors.objective)}
+          />
+          {errors.objective && <p className={styles.error}>{errors.objective}</p>}
+
+          <label htmlFor="promiseeName">Commitment recipient name</label>
+          <input
+            id="promiseeName"
+            name="promiseeName"
+            value={form.promiseeName}
+            onChange={handleChange}
+            aria-invalid={Boolean(errors.promiseeName)}
+          />
+          {errors.promiseeName && <p className={styles.error}>{errors.promiseeName}</p>}
+
+          <label htmlFor="promiseeScope">Commitment scope</label>
+          <select
+            id="promiseeScope"
+            name="promiseeScope"
+            value={form.promiseeScope}
+            onChange={handleChange}
+            aria-invalid={Boolean(errors.promiseeScope)}
+          >
+            <option value="" disabled>
+              Select commitment scope
+            </option>
+            <option value="self">Self</option>
+            <option value="individual">Individual</option>
+            <option value="organization">Organization</option>
+            <option value="public">Public</option>
+          </select>
+          {errors.promiseeScope && <p className={styles.error}>{errors.promiseeScope}</p>}
+
+          <label htmlFor="domain">Domain</label>
+          <input
+            id="domain"
+            name="domain"
+            value={form.domain}
+            onChange={handleChange}
+            aria-invalid={Boolean(errors.domain)}
+          />
+          {errors.domain && <p className={styles.error}>{errors.domain}</p>}
+
+          <label htmlFor="days">Timeline (days)</label>
+          <input
+            id="days"
+            name="days"
+            type="number"
+            min="1"
+            value={form.days}
+            onChange={handleChange}
+            aria-invalid={Boolean(errors.days)}
+          />
+          {errors.days && <p className={styles.error}>{errors.days}</p>}
+
+          <label htmlFor="successCriteria">Success criteria</label>
+          <textarea
+            id="successCriteria"
+            name="successCriteria"
+            rows="4"
+            value={form.successCriteria}
+            onChange={handleChange}
+            aria-invalid={Boolean(errors.successCriteria)}
+          />
+          {errors.successCriteria && <p className={styles.error}>{errors.successCriteria}</p>}
+
+          <fieldset className={styles.fieldset}>
+            <legend>Deposit type</legend>
+            <label className={styles.inlineOption}>
+              <input
+                type="radio"
+                name="stakeType"
+                value="reputational"
+                checked={form.stakeType === 'reputational'}
+                onChange={handleChange}
+              />
+              Reputational
+            </label>
+            <label className={styles.inlineOption}>
+              <input
+                type="radio"
+                name="stakeType"
+                value="financial"
+                checked={form.stakeType === 'financial'}
+                onChange={handleChange}
+              />
+              Financial
+            </label>
+          </fieldset>
+
+          {form.stakeType === 'financial' && (
+            <>
+              <label htmlFor="stakeAmount">Deposit amount</label>
+              <input
+                id="stakeAmount"
+                name="stakeAmount"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={form.stakeAmount}
+                onChange={handleChange}
+                aria-invalid={Boolean(errors.stakeAmount)}
+              />
+              {errors.stakeAmount && <p className={styles.error}>{errors.stakeAmount}</p>}
+            </>
+          )}
+
+          <button className={styles.submitButton} type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Submitting...' : 'Submit Commitment'}
+          </button>
+        </form>
+
+        {submitSuccess && <p className={styles.success}>{submitSuccess}</p>}
+        {submitError && <p className={styles.error}>{submitError}</p>}
+      </main>
+    </div>
+  );
+}

--- a/src/pages/CreatePromise.jsx
+++ b/src/pages/CreatePromise.jsx
@@ -64,6 +64,8 @@ export default function CreatePromise() {
   };
 
   const buildPayload = () => {
+    // PP-008 requires collecting promiseeName in the UI, but the current
+    // backend contract for POST /api/promises does not accept that field yet.
     const payload = {
       promiserId: CURRENT_USER,
       promiseeScope: form.promiseeScope,

--- a/src/pages/CreatePromise.module.css
+++ b/src/pages/CreatePromise.module.css
@@ -1,0 +1,100 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 16px;
+  color: #f4f5ff;
+}
+
+.card {
+  width: 100%;
+  max-width: 680px;
+  background: #151723;
+  border: 1px solid #2a2f45;
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.heading {
+  font-size: 30px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.subheading {
+  color: #b7bdd6;
+  margin-bottom: 20px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.form label {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.form input,
+.form select,
+.form textarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #3a4260;
+  padding: 10px 12px;
+  background: #101321;
+  color: #f4f5ff;
+}
+
+.form textarea {
+  resize: vertical;
+}
+
+.fieldset {
+  margin-top: 8px;
+  border: 1px solid #3a4260;
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  gap: 24px;
+}
+
+.inlineOption {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inlineOption input {
+  width: auto;
+}
+
+.submitButton {
+  margin-top: 12px;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: #3f7cff;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.submitButton:disabled {
+  background: #2c4e99;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #ff9ba5;
+  font-size: 14px;
+}
+
+.success {
+  color: #7ee787;
+  margin-top: 12px;
+  font-weight: 600;
+}

--- a/src/pages/CreatePromise.test.jsx
+++ b/src/pages/CreatePromise.test.jsx
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreatePromise from './CreatePromise';
+
+vi.mock('../services/api', () => ({
+  createPromise: vi.fn(),
+}));
+
+import { createPromise } from '../services/api';
+
+describe('CreatePromise', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('shows validation errors when required fields are empty', async () => {
+    const user = userEvent.setup();
+    render(<CreatePromise />);
+
+    await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
+
+    expect(screen.getByText('Commitment objective is required.')).toBeInTheDocument();
+    expect(screen.getByText('Commitment recipient is required.')).toBeInTheDocument();
+    expect(screen.getByText('Commitment scope is required.')).toBeInTheDocument();
+    expect(screen.getByText('Domain is required.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Timeline must be a positive whole number of days.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Success criteria is required.')).toBeInTheDocument();
+    expect(createPromise).not.toHaveBeenCalled();
+  });
+
+  test('shows amount input only for Financial deposit type', async () => {
+    const user = userEvent.setup();
+    render(<CreatePromise />);
+
+    expect(screen.queryByLabelText('Deposit amount')).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Financial'));
+    expect(screen.getByLabelText('Deposit amount')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Reputational'));
+    expect(screen.queryByLabelText('Deposit amount')).not.toBeInTheDocument();
+  });
+
+  test('submits correct payload for financial deposit', async () => {
+    const user = userEvent.setup();
+    createPromise.mockResolvedValue({ id: 'prm_999' });
+    render(<CreatePromise />);
+
+    await user.type(screen.getByLabelText('Commitment objective'), 'Ship PP-008');
+    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'organization');
+    await user.type(screen.getByLabelText('Domain'), 'Engineering');
+    await user.type(screen.getByLabelText('Timeline (days)'), '30');
+    await user.type(screen.getByLabelText('Success criteria'), 'Form is accepted by backend');
+    await user.click(screen.getByLabelText('Financial'));
+    await user.type(screen.getByLabelText('Deposit amount'), '250');
+
+    await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
+
+    await waitFor(() => {
+      expect(createPromise).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createPromise).toHaveBeenCalledWith({
+      promiserId: 'dev_user_001',
+      promiseeScope: 'organization',
+      domain: 'Engineering',
+      objective: 'Ship PP-008',
+      days: 30,
+      successCriteria: 'Form is accepted by backend',
+      stake: {
+        type: 'financial',
+        amount: 250,
+      },
+    });
+  });
+
+  test('submits correct payload for reputational deposit without amount', async () => {
+    const user = userEvent.setup();
+    createPromise.mockResolvedValue({ id: 'prm_1001' });
+    render(<CreatePromise />);
+
+    await user.type(screen.getByLabelText('Commitment objective'), 'Ship PP-008');
+    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'self');
+    await user.type(screen.getByLabelText('Domain'), 'Engineering');
+    await user.type(screen.getByLabelText('Timeline (days)'), '21');
+    await user.type(screen.getByLabelText('Success criteria'), 'All validations pass');
+
+    await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
+
+    await waitFor(() => {
+      expect(createPromise).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createPromise).toHaveBeenCalledWith({
+      promiserId: 'dev_user_001',
+      promiseeScope: 'self',
+      domain: 'Engineering',
+      objective: 'Ship PP-008',
+      days: 21,
+      successCriteria: 'All validations pass',
+      stake: {
+        type: 'reputational',
+      },
+    });
+    expect(createPromise.mock.calls[0][0].stake).not.toHaveProperty('amount');
+  });
+
+  test('renders success state after successful submission', async () => {
+    const user = userEvent.setup();
+    createPromise.mockResolvedValue({ id: 'prm_1000' });
+    render(<CreatePromise />);
+
+    await user.type(screen.getByLabelText('Commitment objective'), 'Submit successful form');
+    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.type(screen.getByLabelText('Domain'), 'Product');
+    await user.type(screen.getByLabelText('Timeline (days)'), '14');
+    await user.type(screen.getByLabelText('Success criteria'), 'Backend returns 201');
+
+    await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Commitment created successfully.')).toBeInTheDocument();
+    });
+  });
+
+  test('renders error state after failed submission', async () => {
+    const user = userEvent.setup();
+    createPromise.mockRejectedValue(new Error('Network error'));
+    render(<CreatePromise />);
+
+    await user.type(screen.getByLabelText('Commitment objective'), 'Submit failing form');
+    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.type(screen.getByLabelText('Domain'), 'Product');
+    await user.type(screen.getByLabelText('Timeline (days)'), '14');
+    await user.type(screen.getByLabelText('Success criteria'), 'Backend returns 500');
+
+    await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to create commitment. Please try again.')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/CreatePromise.test.jsx
+++ b/src/pages/CreatePromise.test.jsx
@@ -117,6 +117,7 @@ describe('CreatePromise', () => {
 
     await user.type(screen.getByLabelText('Commitment objective'), 'Submit successful form');
     await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'individual');
     await user.type(screen.getByLabelText('Domain'), 'Product');
     await user.type(screen.getByLabelText('Timeline (days)'), '14');
     await user.type(screen.getByLabelText('Success criteria'), 'Backend returns 201');
@@ -135,6 +136,7 @@ describe('CreatePromise', () => {
 
     await user.type(screen.getByLabelText('Commitment objective'), 'Submit failing form');
     await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'public');
     await user.type(screen.getByLabelText('Domain'), 'Product');
     await user.type(screen.getByLabelText('Timeline (days)'), '14');
     await user.type(screen.getByLabelText('Success criteria'), 'Backend returns 500');


### PR DESCRIPTION
## Summary

- Build the PP-008 Create Commitment screen as the primary promise submission form.
- Add full client-side validation for required fields and backend-aligned constraints.
- Implement deposit type toggle behavior:
  - `Reputational` hides amount input
  - `Financial` shows amount input and requires positive amount
- Submit `POST /api/promises` payload via Axios using required protocol-layer fields.
- Ensure reputational submissions omit `stake.amount` entirely (do not send `null`).
- Add component tests for:
  - required field validation
  - deposit toggle behavior
  - correct financial payload
  - correct reputational payload (without `stake.amount`)
  - success state on mocked success response
  - error state on mocked failure response

## Related Issue

Closes #8 (PP-008)

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [ ] All tests pass locally
- [x] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed