### PR TITLE
feat: implement client-side routing (PP-013)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "axios": "^1.13.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.14.2"
+        "react-router-dom": "^7.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -4394,9 +4394,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4416,12 +4416,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^1.13.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.14.2"
+    "react-router-dom": "^7.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,31 @@
-import './App.css';
-import CreatePromise from './pages/CreatePromise';
+import { Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import MyPromises from './pages/MyPromises';
+import CreatePromise from './pages/CreatePromise';
+import PromiseDetail from './pages/PromiseDetail';
+import PublicProfile from './pages/PublicProfile';
+import './App.css';
+
+function NotFound() {
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h2>404 — Page Not Found</h2>
+      <p>The page you're looking for doesn't exist.</p>
+    </div>
+  );
+}
 
 function App() {
-  return <MyPromises />;
+  return (
+    <Routes>
+      <Route path="/" element={<Dashboard />} />
+      <Route path="/promises" element={<MyPromises />} />
+      <Route path="/promises/:id" element={<PromiseDetail />} />
+      <Route path="/create" element={<CreatePromise />} />
+      <Route path="/profile" element={<PublicProfile />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  );
 }
 
 export default App;

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,64 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+
+vi.mock('./pages/Dashboard', () => ({
+  default: () => <div>Dashboard Page</div>,
+}));
+
+vi.mock('./pages/MyPromises', () => ({
+  default: () => <div>My Promises Page</div>,
+}));
+
+vi.mock('./pages/CreatePromise', () => ({
+  default: () => <div>Create Promise Page</div>,
+}));
+
+vi.mock('./pages/PublicProfile', () => ({
+  default: () => <div>Public Profile Page</div>,
+}));
+
+vi.mock('./pages/PromiseDetail', () => ({
+  default: () => <div>Promise Detail Page</div>,
+}));
+
+function renderAtRoute(route) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <App />
+    </MemoryRouter>
+  );
+}
+
+describe('App routing', () => {
+  test('/ renders Dashboard', () => {
+    renderAtRoute('/');
+    expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+  });
+
+  test('/promises renders MyPromises', () => {
+    renderAtRoute('/promises');
+    expect(screen.getByText('My Promises Page')).toBeInTheDocument();
+  });
+
+  test('/promises/:id renders PromiseDetail', () => {
+    renderAtRoute('/promises/prm_001');
+    expect(screen.getByText('Promise Detail Page')).toBeInTheDocument();
+  });
+
+  test('/create renders CreatePromise', () => {
+    renderAtRoute('/create');
+    expect(screen.getByText('Create Promise Page')).toBeInTheDocument();
+  });
+
+  test('/profile renders PublicProfile', () => {
+    renderAtRoute('/profile');
+    expect(screen.getByText('Public Profile Page')).toBeInTheDocument();
+  });
+
+  test('undefined route renders 404 page', () => {
+    renderAtRoute('/this-does-not-exist');
+    expect(screen.getByText('404 — Page Not Found')).toBeInTheDocument();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/PromiseDetail.jsx
+++ b/src/pages/PromiseDetail.jsx
@@ -1,9 +1,7 @@
 import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { getPromises, getAssessments } from '../services/api';
 import styles from './PromiseDetail.module.css';
-
-// Epic 3 note: replace with useParams() from React Router
-// Epic 3 note: replace promiseId prop with route param
 
 const STATUS = {
   pending: { label: 'Active', color: '#4FC3F7', bg: 'rgba(79,195,247,0.10)' },
@@ -11,7 +9,9 @@ const STATUS = {
   BROKEN: { label: 'Broken', color: '#E05252', bg: 'rgba(224,82,82,0.10)' },
 };
 
-export default function PromiseDetail({ promiseId }) {
+export default function PromiseDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
   const [promise, setPromise] = useState(null);
   const [assessments, setAssessments] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -26,7 +26,7 @@ export default function PromiseDetail({ promiseId }) {
           getAssessments(),
         ]);
 
-        const matched = allPromises.find((p) => p.id === promiseId);
+        const matched = allPromises.find((p) => p.id === id);
 
         if (!matched) {
           setNotFound(true);
@@ -34,7 +34,7 @@ export default function PromiseDetail({ promiseId }) {
         }
 
         const linkedAssessments = allAssessments.filter(
-          (a) => a.promiseId === promiseId
+          (a) => a.promiseId === id
         );
 
         setPromise(matched);
@@ -46,10 +46,8 @@ export default function PromiseDetail({ promiseId }) {
       }
     }
 
-    if (promiseId) {
-      fetchData();
-    }
-  }, [promiseId]);
+    fetchData();
+  }, [id]);
 
   if (loading) {
     return (
@@ -83,10 +81,7 @@ export default function PromiseDetail({ promiseId }) {
       ? `$${promise.stake.amount}`
       : 'Reputation';
 
-  const timelineDisplay =
-    status === 'pending'
-      ? '--' // Epic 3 stub: days remaining calculation pending clarification
-      : 'Closed';
+  const timelineDisplay = status === 'pending' ? '--' : 'Closed';
 
   const createdAtDisplay = new Date(promise.createdAt).toLocaleDateString(
     'en-US',
@@ -95,18 +90,14 @@ export default function PromiseDetail({ promiseId }) {
 
   return (
     <div className={styles.container}>
-      {/* Back navigation — Epic 3: replace with useNavigate() */}
       <button
         className={styles.backButton}
-        onClick={() =>
-          console.log('Navigate back to My Promises — wired in Epic 3')
-        }
+        onClick={() => navigate('/promises')}
       >
         ← Back to Promises
       </button>
 
       <div className={styles.content}>
-        {/* Promise Card */}
         <div className={styles.promiseCard}>
           <div className={styles.statusBar} style={{ background: cfg.color }} />
           <div className={styles.promiseCardBody}>
@@ -143,7 +134,6 @@ export default function PromiseDetail({ promiseId }) {
           </div>
         </div>
 
-        {/* Assessments Card */}
         <div className={styles.assessmentsCard}>
           <div className={styles.assessmentsHeader}>Assessments</div>
           {assessments.length === 0 ? (
@@ -176,7 +166,6 @@ export default function PromiseDetail({ promiseId }) {
           )}
         </div>
 
-        {/* Submit Assessment CTA — Epic 3: wire navigation to PP-012 */}
         {status === 'pending' && (
           <div className={styles.ctaCard}>
             <div>
@@ -187,9 +176,7 @@ export default function PromiseDetail({ promiseId }) {
             </div>
             <button
               className={styles.ctaButton}
-              onClick={() =>
-                console.log('Navigate to Submit Assessment — wired in Epic 3')
-              }
+              onClick={() => navigate('/create')}
             >
               Submit Assessment
             </button>

--- a/src/pages/PromiseDetail.test.jsx
+++ b/src/pages/PromiseDetail.test.jsx
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import PromiseDetail from './PromiseDetail';
 
 vi.mock('../services/api', () => ({
@@ -41,12 +42,22 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+function renderWithRouter(id) {
+  return render(
+    <MemoryRouter initialEntries={[`/promises/${id}`]}>
+      <Routes>
+        <Route path="/promises/:id" element={<PromiseDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe('PromiseDetail', () => {
   test('renders all promise fields correctly with mocked data', async () => {
     getPromises.mockResolvedValue([mockPendingPromise]);
     getAssessments.mockResolvedValue([]);
 
-    render(<PromiseDetail promiseId="prm_001" />);
+    renderWithRouter('prm_001');
 
     await waitFor(() => {
       expect(
@@ -64,7 +75,7 @@ describe('PromiseDetail', () => {
     getPromises.mockResolvedValue([mockPendingPromise]);
     getAssessments.mockResolvedValue([]);
 
-    render(<PromiseDetail promiseId="prm_001" />);
+    renderWithRouter('prm_001');
 
     await waitFor(() => {
       expect(screen.getByText('Submit Assessment')).toBeInTheDocument();
@@ -75,7 +86,7 @@ describe('PromiseDetail', () => {
     getPromises.mockResolvedValue([mockKeptPromise]);
     getAssessments.mockResolvedValue([]);
 
-    render(<PromiseDetail promiseId="prm_002" />);
+    renderWithRouter('prm_002');
 
     await waitFor(() => {
       expect(
@@ -90,7 +101,7 @@ describe('PromiseDetail', () => {
     getPromises.mockResolvedValue([mockPendingPromise]);
     getAssessments.mockResolvedValue([]);
 
-    render(<PromiseDetail promiseId="prm_001" />);
+    renderWithRouter('prm_001');
 
     await waitFor(() => {
       expect(
@@ -103,7 +114,7 @@ describe('PromiseDetail', () => {
     getPromises.mockResolvedValue([mockPendingPromise]);
     getAssessments.mockResolvedValue([mockAssessment]);
 
-    render(<PromiseDetail promiseId="prm_001" />);
+    renderWithRouter('prm_001');
 
     await waitFor(() => {
       expect(screen.getByText('dev_user_001')).toBeInTheDocument();
@@ -112,11 +123,11 @@ describe('PromiseDetail', () => {
     expect(screen.getByText('Apr 5, 2026')).toBeInTheDocument();
   });
 
-  test('renders not found state when promiseId does not match any promise', async () => {
+  test('renders not found state when id does not match any promise', async () => {
     getPromises.mockResolvedValue([mockPendingPromise]);
     getAssessments.mockResolvedValue([]);
 
-    render(<PromiseDetail promiseId="prm_999" />);
+    renderWithRouter('prm_999');
 
     await waitFor(() => {
       expect(screen.getByText('Promise not found.')).toBeInTheDocument();
@@ -127,7 +138,7 @@ describe('PromiseDetail', () => {
     getPromises.mockRejectedValue(new Error('Network error'));
     getAssessments.mockRejectedValue(new Error('Network error'));
 
-    render(<PromiseDetail promiseId="prm_001" />);
+    renderWithRouter('prm_001');
 
     await waitFor(() => {
       expect(
@@ -140,7 +151,7 @@ describe('PromiseDetail', () => {
     getPromises.mockResolvedValue([mockPendingPromise]);
     getAssessments.mockResolvedValue([]);
 
-    render(<PromiseDetail promiseId="prm_001" />);
+    renderWithRouter('prm_001');
 
     await waitFor(() => {
       expect(screen.getByText('← Back to Promises')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Installs React Router and implements client-side routing across the app. Replaces the hardcoded component render in App.jsx with a full route structure. Refactors PromiseDetail to read promiseId from URL params via useParams() rather than props. BrowserRouter moved to main.jsx so App.jsx is testable in isolation.

## Related Issue

<!-- Link the backlog item this PR addresses -->

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/16

Closes #

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [x] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [x] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

Manual testing confirmed all routes load the correct component. 404 page renders on undefined routes.

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

- BrowserRouter moved from App.jsx to main.jsx - this is intentional and required for testing
- PromiseDetail.test.jsx updated to use MemoryRouter + route params instead of prop-based rendering
- App.test.jsx is a new file covering all route definitions and the 404 fallback
- React Router adds 5 new packages to package-lock.json - expected