### PR TITLE
test: add regression test for listPromises return value (PP-038)

### DIFF
--- a/server/__tests__/cli.test.js
+++ b/server/__tests__/cli.test.js
@@ -1,0 +1,51 @@
+const { getPromises, getAssessmentSummary } = require('../src/Storage');
+const { listPromises } = require('../src/cli');
+
+jest.mock('../src/Storage', () => ({
+  getPromises: jest.fn(),
+  getAssessmentSummary: jest.fn(),
+  savePromise: jest.fn(),
+  saveAssessment: jest.fn(),
+  updatePromise: jest.fn()
+}));
+
+describe('cli.js - listPromises Regression Test (PP-038)', () => {
+  let consoleSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  test('returns an empty array when no promises exist', () => {
+    getPromises.mockReturnValue([]);
+
+    const result = listPromises();
+
+    expect(result).toBeDefined();
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+    expect(result).toEqual([]);
+  });
+
+  test('returns an array containing promises when promises exist', () => {
+    const mockPromises = [
+      { id: 'prm_001', domain: 'Web Dev', objective: 'Test data' }
+    ];
+    getPromises.mockReturnValue(mockPromises);
+    getAssessmentSummary.mockReturnValue({ kept: 0, broken: 0 });
+
+    const result = listPromises();
+
+    expect(result).toBeDefined();
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result).toEqual(mockPromises);
+  });
+});


### PR DESCRIPTION
## Summary

Added a regression test for `listPromises` in `server/src/cli.js`. During Sprint 2, a bug was fixed where the function logged data but failed to return it, causing the API to return empty arrays even when promises existed. This test locks in the expected return values (both empty and populated states) to ensure a future refactor cannot silently break the API response again.

## Related Issue

Closes #PP-038

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

N/A - Backend unit tests only.

## Notes for Reviewer

The tests are isolated from the real database. I mocked the `Storage` module to return controlled mock data (`jest.fn().mockReturnValue()`) to verify the function's internal logic without risking database pollution. `getAssessmentSummary` is also mocked to prevent the `forEach` logging loop from throwing undefined errors during the populated state test.