### PR TITLE
feat: add promiseeName frontend stub (PP-031)

### DIFF
--- a/src/pages/CreatePromise.jsx
+++ b/src/pages/CreatePromise.jsx
@@ -39,13 +39,21 @@ export default function CreatePromise() {
   const validate = () => {
     const nextErrors = {};
 
-    if (!form.objective.trim()) nextErrors.objective = 'Commitment objective is required.';
-    if (!form.promiseeName.trim()) nextErrors.promiseeName = 'Commitment recipient is required.';
-    if (!form.promiseeScope) nextErrors.promiseeScope = 'Commitment scope is required.';
+    if (!form.objective.trim())
+      nextErrors.objective = 'Commitment objective is required.';
+    if (!form.promiseeName.trim())
+      nextErrors.promiseeName = 'Commitment recipient is required.';
+    if (!form.promiseeScope)
+      nextErrors.promiseeScope = 'Commitment scope is required.';
     if (!form.domain.trim()) nextErrors.domain = 'Domain is required.';
 
     const daysNumber = Number(form.days);
-    if (!form.days || Number.isNaN(daysNumber) || !Number.isInteger(daysNumber) || daysNumber <= 0) {
+    if (
+      !form.days ||
+      Number.isNaN(daysNumber) ||
+      !Number.isInteger(daysNumber) ||
+      daysNumber <= 0
+    ) {
       nextErrors.days = 'Timeline must be a positive whole number of days.';
     }
 
@@ -55,8 +63,13 @@ export default function CreatePromise() {
 
     if (form.stakeType === 'financial') {
       const amountNumber = Number(form.stakeAmount);
-      if (!form.stakeAmount || Number.isNaN(amountNumber) || amountNumber <= 0) {
-        nextErrors.stakeAmount = 'Financial deposit amount must be a positive number.';
+      if (
+        !form.stakeAmount ||
+        Number.isNaN(amountNumber) ||
+        amountNumber <= 0
+      ) {
+        nextErrors.stakeAmount =
+          'Financial deposit amount must be a positive number.';
       }
     }
 
@@ -64,11 +77,13 @@ export default function CreatePromise() {
   };
 
   const buildPayload = () => {
-    // PP-008 requires collecting promiseeName in the UI, but the current
-    // backend contract for POST /api/promises does not accept that field yet.
+    // PP-031: promiseeName is included in the payload as a frontend stub.
+    // The backend does not currently store this field but will silently ignore it.
+    // Full backend support is deferred to Sprint 4.
     const payload = {
       promiserId: CURRENT_USER,
       promiseeScope: form.promiseeScope,
+      promiseeName: form.promiseeName.trim(),
       domain: form.domain.trim(),
       objective: form.objective.trim(),
       days: Number(form.days),
@@ -114,7 +129,9 @@ export default function CreatePromise() {
     <div className={styles.page}>
       <main className={styles.card}>
         <h1 className={styles.heading}>Create Commitment</h1>
-        <p className={styles.subheading}>Record your commitment details below.</p>
+        <p className={styles.subheading}>
+          Record your commitment details below.
+        </p>
 
         <form className={styles.form} onSubmit={handleSubmit} noValidate>
           <label htmlFor="objective">Commitment objective</label>
@@ -125,7 +142,9 @@ export default function CreatePromise() {
             onChange={handleChange}
             aria-invalid={Boolean(errors.objective)}
           />
-          {errors.objective && <p className={styles.error}>{errors.objective}</p>}
+          {errors.objective && (
+            <p className={styles.error}>{errors.objective}</p>
+          )}
 
           <label htmlFor="promiseeName">Commitment recipient name</label>
           <input
@@ -135,7 +154,9 @@ export default function CreatePromise() {
             onChange={handleChange}
             aria-invalid={Boolean(errors.promiseeName)}
           />
-          {errors.promiseeName && <p className={styles.error}>{errors.promiseeName}</p>}
+          {errors.promiseeName && (
+            <p className={styles.error}>{errors.promiseeName}</p>
+          )}
 
           <label htmlFor="promiseeScope">Commitment scope</label>
           <select
@@ -153,7 +174,9 @@ export default function CreatePromise() {
             <option value="organization">Organization</option>
             <option value="public">Public</option>
           </select>
-          {errors.promiseeScope && <p className={styles.error}>{errors.promiseeScope}</p>}
+          {errors.promiseeScope && (
+            <p className={styles.error}>{errors.promiseeScope}</p>
+          )}
 
           <label htmlFor="domain">Domain</label>
           <input
@@ -186,7 +209,9 @@ export default function CreatePromise() {
             onChange={handleChange}
             aria-invalid={Boolean(errors.successCriteria)}
           />
-          {errors.successCriteria && <p className={styles.error}>{errors.successCriteria}</p>}
+          {errors.successCriteria && (
+            <p className={styles.error}>{errors.successCriteria}</p>
+          )}
 
           <fieldset className={styles.fieldset}>
             <legend>Deposit type</legend>
@@ -225,11 +250,17 @@ export default function CreatePromise() {
                 onChange={handleChange}
                 aria-invalid={Boolean(errors.stakeAmount)}
               />
-              {errors.stakeAmount && <p className={styles.error}>{errors.stakeAmount}</p>}
+              {errors.stakeAmount && (
+                <p className={styles.error}>{errors.stakeAmount}</p>
+              )}
             </>
           )}
 
-          <button className={styles.submitButton} type="submit" disabled={isSubmitting}>
+          <button
+            className={styles.submitButton}
+            type="submit"
+            disabled={isSubmitting}
+          >
             {isSubmitting ? 'Submitting...' : 'Submit Commitment'}
           </button>
         </form>

--- a/src/pages/CreatePromise.test.jsx
+++ b/src/pages/CreatePromise.test.jsx
@@ -20,14 +20,22 @@ describe('CreatePromise', () => {
 
     await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
 
-    expect(screen.getByText('Commitment objective is required.')).toBeInTheDocument();
-    expect(screen.getByText('Commitment recipient is required.')).toBeInTheDocument();
-    expect(screen.getByText('Commitment scope is required.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Commitment objective is required.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Commitment recipient is required.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Commitment scope is required.')
+    ).toBeInTheDocument();
     expect(screen.getByText('Domain is required.')).toBeInTheDocument();
     expect(
       screen.getByText('Timeline must be a positive whole number of days.')
     ).toBeInTheDocument();
-    expect(screen.getByText('Success criteria is required.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Success criteria is required.')
+    ).toBeInTheDocument();
     expect(createPromise).not.toHaveBeenCalled();
   });
 
@@ -49,12 +57,24 @@ describe('CreatePromise', () => {
     createPromise.mockResolvedValue({ id: 'prm_999' });
     render(<CreatePromise />);
 
-    await user.type(screen.getByLabelText('Commitment objective'), 'Ship PP-008');
-    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
-    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'organization');
+    await user.type(
+      screen.getByLabelText('Commitment objective'),
+      'Ship PP-008'
+    );
+    await user.type(
+      screen.getByLabelText('Commitment recipient name'),
+      'Jordan'
+    );
+    await user.selectOptions(
+      screen.getByLabelText('Commitment scope'),
+      'organization'
+    );
     await user.type(screen.getByLabelText('Domain'), 'Engineering');
     await user.type(screen.getByLabelText('Timeline (days)'), '30');
-    await user.type(screen.getByLabelText('Success criteria'), 'Form is accepted by backend');
+    await user.type(
+      screen.getByLabelText('Success criteria'),
+      'Form is accepted by backend'
+    );
     await user.click(screen.getByLabelText('Financial'));
     await user.type(screen.getByLabelText('Deposit amount'), '250');
 
@@ -67,6 +87,7 @@ describe('CreatePromise', () => {
     expect(createPromise).toHaveBeenCalledWith({
       promiserId: 'dev_user_001',
       promiseeScope: 'organization',
+      promiseeName: 'Jordan',
       domain: 'Engineering',
       objective: 'Ship PP-008',
       days: 30,
@@ -83,12 +104,21 @@ describe('CreatePromise', () => {
     createPromise.mockResolvedValue({ id: 'prm_1001' });
     render(<CreatePromise />);
 
-    await user.type(screen.getByLabelText('Commitment objective'), 'Ship PP-008');
-    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
+    await user.type(
+      screen.getByLabelText('Commitment objective'),
+      'Ship PP-008'
+    );
+    await user.type(
+      screen.getByLabelText('Commitment recipient name'),
+      'Jordan'
+    );
     await user.selectOptions(screen.getByLabelText('Commitment scope'), 'self');
     await user.type(screen.getByLabelText('Domain'), 'Engineering');
     await user.type(screen.getByLabelText('Timeline (days)'), '21');
-    await user.type(screen.getByLabelText('Success criteria'), 'All validations pass');
+    await user.type(
+      screen.getByLabelText('Success criteria'),
+      'All validations pass'
+    );
 
     await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
 
@@ -99,6 +129,7 @@ describe('CreatePromise', () => {
     expect(createPromise).toHaveBeenCalledWith({
       promiserId: 'dev_user_001',
       promiseeScope: 'self',
+      promiseeName: 'Jordan',
       domain: 'Engineering',
       objective: 'Ship PP-008',
       days: 21,
@@ -115,17 +146,31 @@ describe('CreatePromise', () => {
     createPromise.mockResolvedValue({ id: 'prm_1000' });
     render(<CreatePromise />);
 
-    await user.type(screen.getByLabelText('Commitment objective'), 'Submit successful form');
-    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
-    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'individual');
+    await user.type(
+      screen.getByLabelText('Commitment objective'),
+      'Submit successful form'
+    );
+    await user.type(
+      screen.getByLabelText('Commitment recipient name'),
+      'Jordan'
+    );
+    await user.selectOptions(
+      screen.getByLabelText('Commitment scope'),
+      'individual'
+    );
     await user.type(screen.getByLabelText('Domain'), 'Product');
     await user.type(screen.getByLabelText('Timeline (days)'), '14');
-    await user.type(screen.getByLabelText('Success criteria'), 'Backend returns 201');
+    await user.type(
+      screen.getByLabelText('Success criteria'),
+      'Backend returns 201'
+    );
 
     await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Commitment created successfully.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Commitment created successfully.')
+      ).toBeInTheDocument();
     });
   });
 
@@ -134,12 +179,24 @@ describe('CreatePromise', () => {
     createPromise.mockRejectedValue(new Error('Network error'));
     render(<CreatePromise />);
 
-    await user.type(screen.getByLabelText('Commitment objective'), 'Submit failing form');
-    await user.type(screen.getByLabelText('Commitment recipient name'), 'Jordan');
-    await user.selectOptions(screen.getByLabelText('Commitment scope'), 'public');
+    await user.type(
+      screen.getByLabelText('Commitment objective'),
+      'Submit failing form'
+    );
+    await user.type(
+      screen.getByLabelText('Commitment recipient name'),
+      'Jordan'
+    );
+    await user.selectOptions(
+      screen.getByLabelText('Commitment scope'),
+      'public'
+    );
     await user.type(screen.getByLabelText('Domain'), 'Product');
     await user.type(screen.getByLabelText('Timeline (days)'), '14');
-    await user.type(screen.getByLabelText('Success criteria'), 'Backend returns 500');
+    await user.type(
+      screen.getByLabelText('Success criteria'),
+      'Backend returns 500'
+    );
 
     await user.click(screen.getByRole('button', { name: 'Submit Commitment' }));
 

--- a/src/pages/PromiseDetail.jsx
+++ b/src/pages/PromiseDetail.jsx
@@ -142,6 +142,12 @@ export default function PromiseDetail() {
                 <div className={styles.metaLabel}>Deposit</div>
                 <div className={styles.metaValue}>{stakeDisplay}</div>
               </div>
+              <div className={styles.metaItem}>
+                <div className={styles.metaLabel}>Promised To</div>
+                <div className={styles.metaValue}>
+                  {promise.promiseeName || '--'}
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/PromiseDetail.test.jsx
+++ b/src/pages/PromiseDetail.test.jsx
@@ -14,6 +14,7 @@ const mockPendingPromise = {
   id: 'prm_001',
   promiserId: 'dev_user_001',
   promiseeScope: 'individual',
+  promiseeName: 'Jordan',
   domain: 'Web Dev',
   objective: 'Build the dashboard screen',
   timeline: 30,
@@ -156,5 +157,35 @@ describe('PromiseDetail', () => {
     await waitFor(() => {
       expect(screen.getByText('← Back to Promises')).toBeInTheDocument();
     });
+  });
+
+  test('renders promiseeName when present', async () => {
+    getPromises.mockResolvedValue([mockPendingPromise]);
+    getAssessments.mockResolvedValue([]);
+
+    renderWithRouter('prm_001');
+
+    await waitFor(() => {
+      expect(screen.getByText('Jordan')).toBeInTheDocument();
+    });
+  });
+
+  test('renders -- fallback when promiseeName is absent', async () => {
+    const promiseWithoutName = {
+      ...mockPendingPromise,
+      promiseeName: undefined,
+    };
+    getPromises.mockResolvedValue([promiseWithoutName]);
+    getAssessments.mockResolvedValue([]);
+
+    renderWithRouter('prm_001');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Build the dashboard screen')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('--').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Wires promiseeName into the frontend as a stub. buildPayload in CreatePromise now includes promiseeName in the request body. PromiseDetail displays promiseeName in the meta grid with a -- fallback if the field is absent. Backend does not currently support this field and will silently ignore it, full backend support is deferred to Sprint 4.


## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/55

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [x] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [x] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

- promiseeName is included in buildPayload but the backend will silently ignore it until the backend field is confirmed in Sprint 4
- PromiseDetail renders promiseeName under a "Promised To" label with -- as fallback when absent
- Payload shape assertions in CreatePromise.test.jsx updated to include promiseeName
- Two new tests added to PromiseDetail.test.jsx covering promiseeName present and absent cases
