### PR TITLE
feat: differentiate true empty and filter empty states (PP-032)

### DIFF
--- a/src/pages/MyPromises.jsx
+++ b/src/pages/MyPromises.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import PromiseCard from '../components/PromiseCard';
 import { getPromises } from '../services/api';
 import styles from './MyPromises.module.css';
@@ -15,6 +16,7 @@ export default function MyPromises() {
   const [selectedFilter, setSelectedFilter] = useState(StatusSearchFilter.All);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function fetchData() {
@@ -75,14 +77,21 @@ export default function MyPromises() {
       </div>
       {loading && <div className={styles.loadingState}>Loading...</div>}
       {error && <div className={styles.errorState}>{error}</div>}
+      
       {!loading && !error && promises.length === 0 ? (
-        <div className={styles.emptyState}>
-          <p className={styles.emptyTitle}>No commitments yet.</p>
+        <div className={`${styles.emptyState} ${styles.trueEmptyState}`}>
+          <p className={styles.emptyTitle}>You haven't made any commitments yet.</p>
+          <button 
+            className={styles.createBtn} 
+            onClick={() => navigate('/create')}
+          >
+            Create your first commitment
+          </button>
         </div>
       ) : !loading && !error && filteredPromises.length === 0 ? (
         <div className={styles.emptyState}>
           <p className={styles.emptyTitle}>
-            No commitments match the selected filter. Try another status.
+            No commitments match this filter.
           </p>
         </div>
       ) : (

--- a/src/pages/MyPromises.module.css
+++ b/src/pages/MyPromises.module.css
@@ -115,6 +115,32 @@
   text-align: center;
 }
 
+.trueEmptyState {
+  border: 2px dashed var(--pp-border);
+  border-radius: var(--pp-border-radius);
+  background-color: var(--pp-surface-hover);
+  padding: 60px 0;
+  margin-top: 20px;
+}
+
+.createBtn {
+  margin-top: 16px;
+  padding: 10px 24px;
+  border-radius: var(--pp-border-radius);
+  border: none;
+  background-color: var(--pp-accent);
+  color: var(--pp-bg);
+  font-family: var(--pp-font-family);
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.createBtn:hover {
+  background-color: var(--pp-accent-dark);
+}
+
 .emptyIcon {
   font-size: 32px;
   color: var(--pp-text-muted);

--- a/src/pages/MyPromises.test.jsx
+++ b/src/pages/MyPromises.test.jsx
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import MyPromises from './MyPromises';
+import { getPromises } from '../services/api';
 
 vi.mock('../services/api', () => ({
   getPromises: vi.fn(),
 }));
 
-import { getPromises } from '../services/api';
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 const mockPromises = [
   {
@@ -53,10 +62,16 @@ describe('MyPromises', () => {
     vi.clearAllMocks();
   });
 
+  const renderWithRouter = () => render(
+    <MemoryRouter>
+      <MyPromises />
+    </MemoryRouter>
+  );
+
   test('renders all promises correctly with mocked API data', async () => {
     getPromises.mockResolvedValue(mockPromises);
 
-    render(<MyPromises />);
+    renderWithRouter();
 
     await waitFor(() => {
       expect(screen.getByText('Pay rent')).toBeInTheDocument();
@@ -71,7 +86,7 @@ describe('MyPromises', () => {
     const user = userEvent.setup();
     getPromises.mockResolvedValue(mockPromises);
 
-    render(<MyPromises />);
+    renderWithRouter();
 
     await waitFor(() => {
       expect(screen.getByText('Pay rent')).toBeInTheDocument();
@@ -93,14 +108,12 @@ describe('MyPromises', () => {
     expect(screen.queryByText('Ship feature')).not.toBeInTheDocument();
   });
 
-  test('renders empty filter state when no promises match the active filter', async () => {
+  test('renders filter empty state when no promises match the active filter', async () => {
     const user = userEvent.setup();
-    const noKeptPromises = mockPromises.filter(
-      (promise) => promise.status !== 'KEPT'
-    );
+    const noKeptPromises = mockPromises.filter((p) => p.status !== 'KEPT');
     getPromises.mockResolvedValue(noKeptPromises);
 
-    render(<MyPromises />);
+    renderWithRouter();
 
     await waitFor(() => {
       expect(screen.getByText('Pay rent')).toBeInTheDocument();
@@ -108,13 +121,25 @@ describe('MyPromises', () => {
 
     await user.click(screen.getByRole('button', { name: 'Kept' }));
 
-    expect(
-      screen.getByText(
-        'No commitments match the selected filter. Try another status.'
-      )
-    ).toBeInTheDocument();
-    expect(screen.queryByText('Pay rent')).not.toBeInTheDocument();
-    expect(screen.queryByText('Fix bug')).not.toBeInTheDocument();
+    expect(screen.getByText('No commitments match this filter.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create your first commitment' })).not.toBeInTheDocument();
+  });
+
+  test('renders true empty state and navigates to /create on click', async () => {
+    const user = userEvent.setup();
+    getPromises.mockResolvedValue([]);
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText("You haven't made any commitments yet.")).toBeInTheDocument();
+    });
+
+    const createBtn = screen.getByRole('button', { name: 'Create your first commitment' });
+    expect(createBtn).toBeInTheDocument();
+
+    await user.click(createBtn);
+    expect(mockNavigate).toHaveBeenCalledWith('/create');
   });
 
   test('clicking a promise card triggers detail navigation behavior', async () => {
@@ -122,7 +147,7 @@ describe('MyPromises', () => {
     getPromises.mockResolvedValue(mockPromises);
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    render(<MyPromises />);
+    renderWithRouter();
 
     await waitFor(() => {
       expect(screen.getByText('Pay rent')).toBeInTheDocument();
@@ -130,9 +155,7 @@ describe('MyPromises', () => {
 
     await user.click(screen.getByText('Pay rent'));
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Navigate to Promise Detail — wired in Epic 3'
-    );
+    expect(consoleSpy).toHaveBeenCalledWith('Navigate to Promise Detail — wired in Epic 3');
 
     consoleSpy.mockRestore();
   });


### PR DESCRIPTION
- Split fallback logic in MyPromises.jsx to handle total vs filtered zero states

- Add dashed border container and accent CTA button in MyPromises.module.css

- Update MyPromises.test.jsx with MemoryRouter mock and true empty assertions

## Summary

This PR implements distinct UI states for the My Promises screen. It splits the fallback logic in MyPromises.jsx to render a dedicated "True Empty" state (with a dashed border container and an accent CTA button) when a user has zero total commitments, and a minimalist "Filter Empty" message when no commitments match the currently selected status filter. It also updates MyPromises.test.jsx with a MemoryRouter mock to ensure the new routing behavior and empty assertions are fully covered.

##Related Issue
Closes PP-032

##Type of Change
[x] Feature
[ ] Bug fix
[ ] Chore / setup
[ ] Docs

##Checklist
[x] My code follows the branch naming convention (type/PP-xxx-short-description)
[x] My commits follow the Conventional Commits format
[x] I have written or updated tests for my changes
[x] All tests pass locally
[x] I have tested this manually in the browser
[x] I have not committed any .env files or secrets
[ ] I have updated relevant documentation if needed

##Screenshots
<img width="1738" height="1084" alt="image" src="https://github.com/user-attachments/assets/bd1667df-d98f-4f47-b5fe-078a303f1cf3" />
<img width="1730" height="1077" alt="image" src="https://github.com/user-attachments/assets/65534cd7-f789-4517-bf2b-79684e77855e" />
<img width="776" height="393" alt="image" src="https://github.com/user-attachments/assets/d56033ac-810b-497a-85f5-3c9748d05f94" />

##Notes for Reviewer
Because the local API currently returns populated mock data on load, the "True Empty" state must be manually triggered for review. To test this locally, open src/pages/MyPromises.jsx, locate the fetchData function, comment out the real data state, and manually pass an empty array like this: setPromises([]). See the third screenshot for the exact line to modify.