### PR TITLE
chore: add SelfTrust module and Jest test suite (PP-050)

### DIFF
--- a/server/__tests__/SelfTrust.test.js
+++ b/server/__tests__/SelfTrust.test.js
@@ -56,6 +56,11 @@ describe('SelfTrust', () => {
       expect(result).toEqual({ score: 100, count: 1 });
     });
 
+    test('skips null or undefined elements in the outcomes array without throwing', () => {
+      const result = computeSelfTrust([{ outcome: 'kept' }, null, undefined]);
+      expect(result).toEqual({ score: 100, count: 1 });
+    });
+
     test('returns neutral score when every outcome in the list is unrecognized', () => {
       const result = computeSelfTrust([{ outcome: 'nonsense' }, { outcome: 'also-nonsense' }]);
       expect(result).toEqual({ score: 50, count: 0 });

--- a/server/__tests__/SelfTrust.test.js
+++ b/server/__tests__/SelfTrust.test.js
@@ -1,0 +1,78 @@
+const { computeSelfTrust, isValidOutcome, OUTCOME_WEIGHTS, VALID_OUTCOMES } = require('../src/SelfTrust');
+
+describe('SelfTrust', () => {
+  describe('isValidOutcome', () => {
+    test('returns true for each recognized outcome state', () => {
+      VALID_OUTCOMES.forEach((outcome) => {
+        expect(isValidOutcome(outcome)).toBe(true);
+      });
+    });
+
+    test('returns false for an unrecognized outcome string', () => {
+      expect(isValidOutcome('lied')).toBe(false);
+      expect(isValidOutcome('')).toBe(false);
+      expect(isValidOutcome(undefined)).toBe(false);
+    });
+  });
+
+  describe('computeSelfTrust', () => {
+    test('returns a neutral score of 50 with count 0 when there is no history', () => {
+      expect(computeSelfTrust([])).toEqual({ score: 50, count: 0 });
+    });
+
+    test('returns a neutral score of 50 when outcomes is not an array', () => {
+      expect(computeSelfTrust(null)).toEqual({ score: 50, count: 0 });
+      expect(computeSelfTrust(undefined)).toEqual({ score: 50, count: 0 });
+    });
+
+    test('scores a single kept outcome at 100', () => {
+      expect(computeSelfTrust([{ outcome: 'kept' }])).toEqual({ score: 100, count: 1 });
+    });
+
+    test('scores a single forgotten outcome at 10', () => {
+      expect(computeSelfTrust([{ outcome: 'forgotten' }])).toEqual({ score: 10, count: 1 });
+    });
+
+    test('core thesis: an honest miss scores higher than a silent lapse', () => {
+      const honestMiss = computeSelfTrust([{ outcome: 'failed_but_noticed' }]);
+      const silentLapse = computeSelfTrust([{ outcome: 'forgotten' }]);
+      expect(honestMiss.score).toBeGreaterThan(silentLapse.score);
+    });
+
+    test('averages multiple outcomes rather than summing them', () => {
+      // kept (1.0) + forgotten (0.1) -> average 0.55 -> 55
+      const result = computeSelfTrust([{ outcome: 'kept' }, { outcome: 'forgotten' }]);
+      expect(result).toEqual({ score: 55, count: 2 });
+    });
+
+    test('honesty pulls a bad record upward: forgotten then kept beats forgotten alone', () => {
+      const justForgotten = computeSelfTrust([{ outcome: 'forgotten' }]);
+      const forgottenThenKept = computeSelfTrust([{ outcome: 'forgotten' }, { outcome: 'kept' }]);
+      expect(forgottenThenKept.score).toBeGreaterThan(justForgotten.score);
+    });
+
+    test('ignores unrecognized outcome values defensively rather than throwing', () => {
+      const result = computeSelfTrust([{ outcome: 'kept' }, { outcome: 'nonsense' }]);
+      expect(result).toEqual({ score: 100, count: 1 });
+    });
+
+    test('returns neutral score when every outcome in the list is unrecognized', () => {
+      const result = computeSelfTrust([{ outcome: 'nonsense' }, { outcome: 'also-nonsense' }]);
+      expect(result).toEqual({ score: 50, count: 0 });
+    });
+
+    test('score always matches a hand-computed average from OUTCOME_WEIGHTS', () => {
+      const outcomes = [
+        { outcome: 'kept' },
+        { outcome: 'kept' },
+        { outcome: 'partially_kept' },
+        { outcome: 'failed_but_noticed' },
+        { outcome: 'kept' },
+      ];
+      const expectedAverage =
+        outcomes.reduce((sum, o) => sum + OUTCOME_WEIGHTS[o.outcome], 0) / outcomes.length;
+      const expectedScore = Math.round(expectedAverage * 100);
+      expect(computeSelfTrust(outcomes).score).toBe(expectedScore);
+    });
+  });
+});

--- a/server/src/SelfTrust.js
+++ b/server/src/SelfTrust.js
@@ -1,0 +1,79 @@
+/**
+ * @file SelfTrust.js
+ * @description Computes a Priya-persona self-trust score from logged behavior outcomes.
+ *
+ * DESIGN PRINCIPLE: self-trust measures HONESTY, not success.
+ * A self-reported outcome can be a lie, so the score is built to reward the act
+ * of honest self-assessment. Keeping a promise is best; honestly admitting a
+ * miss still earns credit; the only thing that does not earn credit is a
+ * total silent lapse (forgotten with no engagement).
+ *
+ * The score is COMPUTED ON READ from the full outcome history. There is no
+ * stored self_trust field that could drift out of sync — the outcomes are the
+ * single source of truth, and the score is always derived from them.
+ *
+ * NOTE: This is an intentionally simple, transparent model for the MVP demo.
+ * It is designed to be legible (you can predict the number by hand) and to be
+ * swapped for a more sophisticated curve later at a single seam: replace
+ * OUTCOME_WEIGHTS and computeSelfTrust, leave the rest.
+ */
+
+// Each behavior outcome contributes a weight in [0, 1].
+// Weight reflects honesty + follow-through, NOT raw success.
+const OUTCOME_WEIGHTS = {
+  kept: 1.0, // did the thing
+  partially_kept: 0.7, // did some of it, reported honestly
+  failed_but_noticed: 0.5, // failed the behavior, but caught and logged it honestly
+  renegotiated: 0.5, // consciously changed the commitment rather than ghosting it
+  forgotten: 0.1, // lapsed; minimal credit, but logging it at all beats silence
+};
+
+const VALID_OUTCOMES = Object.keys(OUTCOME_WEIGHTS);
+
+/**
+ * Whether a string is a recognized behavior outcome.
+ * @param {string} outcome
+ * @returns {boolean}
+ */
+function isValidOutcome(outcome) {
+  return VALID_OUTCOMES.includes(outcome);
+}
+
+/**
+ * Computes a self-trust score (0–100) from a list of logged outcomes.
+ *
+ * The score is the average outcome weight, scaled to 0–100. Averaging (rather
+ * than summing) means the score reflects a person's pattern of honesty over
+ * time, not just their volume of activity — 10 honest misses should not
+ * out-score 3 kept promises.
+ *
+ * @param {Array<{outcome: string}>} outcomes - logged outcome records, oldest to newest
+ * @returns {{ score: number, count: number }} score in [0,100], and how many outcomes fed it
+ */
+function computeSelfTrust(outcomes) {
+  if (!Array.isArray(outcomes) || outcomes.length === 0) {
+    // No history yet. Neutral starting point so a brand-new promise
+    // does not read as either trustworthy or untrustworthy.
+    return { score: 50, count: 0 };
+  }
+
+  const weights = outcomes
+    .map((o) => OUTCOME_WEIGHTS[o.outcome])
+    .filter((w) => typeof w === "number"); // ignore unrecognized outcomes defensively
+
+  if (weights.length === 0) {
+    return { score: 50, count: 0 };
+  }
+
+  const average = weights.reduce((sum, w) => sum + w, 0) / weights.length;
+  const score = Math.round(average * 100);
+
+  return { score, count: weights.length };
+}
+
+module.exports = {
+  OUTCOME_WEIGHTS,
+  VALID_OUTCOMES,
+  isValidOutcome,
+  computeSelfTrust,
+};

--- a/server/src/SelfTrust.js
+++ b/server/src/SelfTrust.js
@@ -52,14 +52,19 @@ function isValidOutcome(outcome) {
  */
 function computeSelfTrust(outcomes) {
   if (!Array.isArray(outcomes) || outcomes.length === 0) {
-    // No history yet. Neutral starting point so a brand-new promise
-    // does not read as either trustworthy or untrustworthy.
     return { score: 50, count: 0 };
   }
 
   const weights = outcomes
+    .filter((o) => {
+      if (o == null) {
+        console.warn('SelfTrust.computeSelfTrust: skipping null/undefined outcome entry');
+        return false;
+      }
+      return true;
+    })
     .map((o) => OUTCOME_WEIGHTS[o.outcome])
-    .filter((w) => typeof w === "number"); // ignore unrecognized outcomes defensively
+    .filter((w) => typeof w === "number");
 
   if (weights.length === 0) {
     return { score: 50, count: 0 };
@@ -67,7 +72,6 @@ function computeSelfTrust(outcomes) {
 
   const average = weights.reduce((sum, w) => sum + w, 0) / weights.length;
   const score = Math.round(average * 100);
-
   return { score, count: weights.length };
 }
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Adds the SelfTrust scoring algorithm (server/src/SelfTrust.js) and its Jest test suite (server/__tests__/SelfTrust.test.js) to the codebase. SelfTrust computes a 0–100 self-trust score from a list of logged behavior outcomes, rewarding honesty over raw success - an honest admission of failure scores meaningfully higher than a silent lapse. Also reinstalls Jest as a dev dependency in server/package.json, which was missing from the server's local node_modules.

## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/92

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

N/A — no UI changes.

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

SelfTrust.js is a working but intentionally placeholder algorithm. The outcome weights (kept: 1.0, failed_but_noticed: 0.5, forgotten: 0.1, etc.) are a calibration stand-in, not a finalized model. PP-A2 and PP-A4 both import from this file, so this PR is a blocker for Sprint 4.
