### PR TITLE
feat: add self-promise support to PromiseModel

### DIFF
--- a/server/__tests__/models/PromiseModel.test.js
+++ b/server/__tests__/models/PromiseModel.test.js
@@ -151,6 +151,143 @@ describe("Promise Data Model", () => {
     });
   });
 
+  describe("Self-Promise Support (kind & visibility)", () => {
+    it("should create a self-promise with no stake, defaulting to private visibility", () => {
+      const promise = new PromiseModel(
+        defaultPromiser,
+        defaultScope,
+        defaultDomain,
+        defaultObjective,
+        defaultTimeline,
+        defaultCriteria,
+        undefined, // stakeType omitted entirely
+        undefined, // stakeAmount omitted entirely
+        undefined, // currency omitted entirely
+        "self",
+      );
+      expect(promise.kind).toBe("self");
+      expect(promise.visibility).toBe("private");
+      expect(promise.stake).toBeNull();
+    });
+
+    it("should reject an explicit non-private visibility on a self-promise", () => {
+      const instantiatePromise = () => {
+        new PromiseModel(
+          defaultPromiser,
+          defaultScope,
+          defaultDomain,
+          defaultObjective,
+          defaultTimeline,
+          defaultCriteria,
+          undefined,
+          undefined,
+          undefined,
+          "self",
+          "group",
+        );
+      };
+      expect(instantiatePromise).toThrow(
+        "Invalid visibility: self-promises must be private",
+      );
+    });
+
+    it("should accept an explicit 'private' visibility on a self-promise", () => {
+      const promise = new PromiseModel(
+        defaultPromiser,
+        defaultScope,
+        defaultDomain,
+        defaultObjective,
+        defaultTimeline,
+        defaultCriteria,
+        undefined,
+        undefined,
+        undefined,
+        "self",
+        "private",
+      );
+      expect(promise.visibility).toBe("private");
+    });
+
+    it("should default kind to 'assessed' and visibility to 'public' when omitted (regression)", () => {
+      const promise = new PromiseModel(
+        defaultPromiser,
+        defaultScope,
+        defaultDomain,
+        defaultObjective,
+        defaultTimeline,
+        defaultCriteria,
+        "financial",
+        10,
+      );
+      expect(promise.kind).toBe("assessed");
+      expect(promise.visibility).toBe("public");
+      expect(promise.stake).toEqual({
+        type: "financial",
+        amount: 10,
+        currency: "USD",
+        status: "held",
+      });
+    });
+
+    it("should still validate a stake normally if a self-promise explicitly provides one", () => {
+      const promise = new PromiseModel(
+        defaultPromiser,
+        defaultScope,
+        defaultDomain,
+        defaultObjective,
+        defaultTimeline,
+        defaultCriteria,
+        "financial",
+        25,
+        "USD",
+        "self",
+      );
+      expect(promise.stake).toEqual({
+        type: "financial",
+        amount: 25,
+        currency: "USD",
+        status: "held",
+      });
+    });
+
+    it("should reject an invalid kind", () => {
+      const instantiatePromise = () => {
+        new PromiseModel(
+          defaultPromiser,
+          defaultScope,
+          defaultDomain,
+          defaultObjective,
+          defaultTimeline,
+          defaultCriteria,
+          undefined,
+          undefined,
+          undefined,
+          "collaborative",
+        );
+      };
+      expect(instantiatePromise).toThrow("Invalid kind");
+    });
+
+    it("should reject an invalid visibility", () => {
+      const instantiatePromise = () => {
+        new PromiseModel(
+          defaultPromiser,
+          defaultScope,
+          defaultDomain,
+          defaultObjective,
+          defaultTimeline,
+          defaultCriteria,
+          undefined,
+          undefined,
+          undefined,
+          "self",
+          "everyone",
+        );
+      };
+      expect(instantiatePromise).toThrow("Invalid visibility");
+    });
+  });
+
   describe("successCriteria Validation (PP-006)", () => {
     it("should accept a valid free-text successCriteria string", () => {
       const promise = new PromiseModel(

--- a/server/models/PromiseModel.js
+++ b/server/models/PromiseModel.js
@@ -6,6 +6,10 @@ class PromiseModel {
     "public",
   ];
 
+  static KIND_VALUES = ["self", "assessed"];
+
+  static VISIBILITY_VALUES = ["private", "group", "public"];
+
   constructor(
     promiserId,
     promiseeScope,
@@ -16,6 +20,8 @@ class PromiseModel {
     stakeType,
     stakeAmount,
     currency,
+    kind,
+    visibility,
   ) {
     this.id = this.generateId();
     this.promiserId = promiserId;
@@ -24,7 +30,16 @@ class PromiseModel {
     this.objective = objective;
     this.timeline = timeline;
     this.successCriteria = this.validateSuccessCriteria(successCriteria);
-    this.stake = this.validateAndFormatStake(stakeType, stakeAmount, currency);
+    // kind must be resolved before stake/visibility, since both depend on it
+    // (self-promises may omit a stake, and default visibility differs by kind).
+    this.kind = this.validateKind(kind);
+    this.visibility = this.validateVisibility(visibility, this.kind);
+    this.stake = this.validateAndFormatStake(
+      stakeType,
+      stakeAmount,
+      currency,
+      this.kind,
+    );
     this.createdAt = new Date();
     this.status = "pending";
   }
@@ -60,12 +75,68 @@ class PromiseModel {
   }
 
   /**
+   * Validates the promise's kind: "self" (no assessor/financial stake required)
+   * or "assessed" (existing default behavior).
+   * Intentionally no legacy fallback, matching validatePromiseeScope's pattern -
+   * but kind is a new field, so omitting it entirely defaults to "assessed"
+   * to keep all existing (pre-self-promise) callers unaffected.
+   */
+  validateKind(kind) {
+    if (kind === undefined || kind === null) {
+      return "assessed";
+    }
+    if (typeof kind !== "string") {
+      throw new Error("Invalid kind");
+    }
+    const normalized = kind.trim().toLowerCase();
+    if (!PromiseModel.KIND_VALUES.includes(normalized)) {
+      throw new Error("Invalid kind");
+    }
+    return normalized;
+  }
+
+  /**
+   * Validates the promise's visibility: "private", "group", or "public".
+   * Self-promises are ALWAYS private - not just by default. A self-promise
+   * may omit visibility (defaults to "private") or pass "private" explicitly,
+   * but any other value throws. This is a deliberate invariant, not a UX
+   * default: self-promises are things like "I promise I'll quit smoking" -
+   * inherently private commitments that should never leak to group/public
+   * visibility, even by caller mistake.
+   */
+  validateVisibility(visibility, kind) {
+    if (visibility === undefined || visibility === null) {
+      return kind === "self" ? "private" : "public";
+    }
+    if (typeof visibility !== "string") {
+      throw new Error("Invalid visibility");
+    }
+    const normalized = visibility.trim().toLowerCase();
+    if (!PromiseModel.VISIBILITY_VALUES.includes(normalized)) {
+      throw new Error("Invalid visibility");
+    }
+    if (kind === "self" && normalized !== "private") {
+      throw new Error("Invalid visibility: self-promises must be private");
+    }
+    return normalized;
+  }
+
+  /**
    * Validates and formats the incoming stake payload.
-   * @param {number|object} input - The raw stake data
-   * @returns {object} { type: 'financial' | 'reputational', amount: number | null, currency: USD, status: 'held'}
+   * @param {number|string} stakeType - The raw stake type, or a legacy numeric amount
+   * @param {number} stakeAmount - The stake amount (for "financial" stakeType)
+   * @param {string} currency - Currency code, defaults to USD
+   * @param {string} kind - "self" or "assessed"; self-promises may omit a stake entirely
+   * @returns {object|null} { type: 'financial' | 'reputational', amount: number | null, currency: USD, status: 'held'} or null for a stake-less self-promise
    * @throws {Error} If the stake type is invalid or data is malformed
    */
-  validateAndFormatStake(stakeType, stakeAmount, currency = "USD") {
+  validateAndFormatStake(stakeType, stakeAmount, currency = "USD", kind = "assessed") {
+    // Self-promises don't require a stake at all. Only short-circuit when no
+    // stake was supplied - a self-promise that DOES supply one still goes
+    // through the normal validation paths below, untouched.
+    if (kind === "self" && stakeType === undefined) {
+      return null;
+    }
     // Catch legacy numeric inputs and convert them to the new financial object
     if (typeof stakeType === "number") {
       return {


### PR DESCRIPTION
Adds kind (self/assessed) and visibility fields. Self-promises skip stake requirement and are always private.

Closes #A1 (PP-A1)

## Summary

<!-- Briefly describe what this PR does and why -->

Extends PromiseModel to support self-promises — low-stakes personal
commitments with no financial/reputational stake and no assessor,
per the Priya MVP flow. Adds two new fields:

- `kind`: "self" | "assessed" (defaults to "assessed" for full backward
  compatibility with existing promises)
- `visibility`: "private" | "group" | "public" (self-promises are
  always private — this is enforced, not just defaulted; attempting to
  set a non-private visibility on a self-promise throws)

Self-promises may omit `stake` entirely. If a stake is provided anyway,
it's validated through the existing financial/reputational paths
unchanged.


## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

https://github.com/users/A-Fujihara/projects/4/views/1?filterQuery=EP-04&pane=issue&itemId=202754876&issue=A-Fujihara%7CPromiseProtocol_WebApp%7C72

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x ] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

- Route (`server/routes/promises.js`) and CLI (`server/src/cli.js`)
  layers are **not** updated in this PR — they still require `stake`
  and don't forward `kind`/`visibility`. That's tracked separately
  as a follow-on ticket needed before self-promises are reachable
  end-to-end via the API.
- `promises.json` sample data has one new self-promise record added
  alongside the two existing legacy records, which are untouched.
