### PR TITLE
feat: wire self-promise support into promises API

### DIFF
--- a/server/__tests__/promises.test.js
+++ b/server/__tests__/promises.test.js
@@ -82,6 +82,62 @@ describe("POST /api/promises", () => {
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty("error");
   });
+
+  describe("Self-Promise Support (PP-A7)", () => {
+    it("should create a self-promise with no stake and return 201 with private visibility", async () => {
+      const res = await request(app)
+        .post("/api/promises")
+        .send({
+          promiserId: "priya_001",
+          promiseeScope: "self",
+          domain: "wellness",
+          objective: "Meditate for 10 minutes every morning",
+          days: 14,
+          successCriteria: "Logged a session on at least 12 of 14 days",
+          kind: "self",
+        });
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty("id");
+      expect(res.body.kind).toBe("self");
+      expect(res.body.visibility).toBe("private");
+      expect(res.body.stake).toBeNull();
+    });
+
+    it("should return 400 for a missing stake when kind is 'assessed' or omitted (regression)", async () => {
+      const res = await request(app)
+        .post("/api/promises")
+        .send({
+          promiserId: "user_001",
+          promiseeScope: "public",
+          domain: "health",
+          objective: "run every day",
+          days: 30,
+          successCriteria: "Complete 30 runs in 30 days",
+        });
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error");
+    });
+
+    it("should return 400 when a self-promise sets an explicit non-private visibility", async () => {
+      const res = await request(app)
+        .post("/api/promises")
+        .send({
+          promiserId: "priya_001",
+          promiseeScope: "self",
+          domain: "wellness",
+          objective: "Meditate for 10 minutes every morning",
+          days: 14,
+          successCriteria: "Logged a session on at least 12 of 14 days",
+          kind: "self",
+          visibility: "group",
+        });
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe(
+        "Invalid visibility: self-promises must be private",
+      );
+    });
+  });
 });
 
 describe("GET /api/promises", () => {

--- a/server/data/promises.json
+++ b/server/data/promises.json
@@ -33,5 +33,19 @@
     },
     "createdAt": "2026-04-10T16:13:14.241Z",
     "status": "pending"
+  },
+  {
+    "id": "prm_1783190009358_dmdg4lk3l",
+    "promiserId": "priya_001",
+    "promiseeScope": "self",
+    "domain": "wellness",
+    "objective": "Meditate for 10 minutes every morning",
+    "timeline": 14,
+    "successCriteria": "Logged a meditation session on at least 12 of 14 days",
+    "kind": "self",
+    "visibility": "private",
+    "stake": null,
+    "createdAt": "2026-07-04T00:00:00.000Z",
+    "status": "pending"
   }
 ]

--- a/server/routes/promises.js
+++ b/server/routes/promises.js
@@ -11,18 +11,20 @@ router.post("/", (req, res) => {
     days,
     stake,
     successCriteria,
+    kind,
+    visibility,
   } = req.body;
+
+  const isSelfPromise = kind === "self";
 
   if (
     !promiserId ||
     !domain ||
     !objective ||
     !days ||
-    !stake ||
-    !stake.type ||
-    stake.amount === undefined ||
     !successCriteria ||
-    successCriteria.trim() === ""
+    successCriteria.trim() === "" ||
+    (!isSelfPromise && (!stake || !stake.type || stake.amount === undefined))
   ) {
     return res.status(400).json({ error: "Missing required fields" });
   }
@@ -35,8 +37,11 @@ router.post("/", (req, res) => {
       objective,
       days,
       successCriteria,
-      stake.type,
-      stake.amount,
+      stake ? stake.type : undefined,
+      stake ? stake.amount : undefined,
+      stake ? stake.currency : undefined,
+      kind,
+      visibility,
     );
     return res.status(201).json(promise);
   } catch (error) {

--- a/server/src/cli.js
+++ b/server/src/cli.js
@@ -21,6 +21,9 @@ const createPromise = (
   successCriteria,
   stakeType,
   stakeAmount,
+  currency,
+  kind,
+  visibility,
 ) => {
   const promise = new PromiseModel(
     promiserId,
@@ -31,6 +34,9 @@ const createPromise = (
     successCriteria,
     stakeType,
     stakeAmount,
+    currency,
+    kind,
+    visibility,
   );
   savePromise(promise);
   console.log(`✓ Promise created: ${promise.id}`);


### PR DESCRIPTION
Routes and CLI now accept kind/visibility and only require a stake when kind is not 'self'.

Closes #A7 (PP-A7)

## Summary

<!-- Briefly describe what this PR does and why -->

Wires the self-promise support added in PP-A1 through to the actual
API and CLI layers, so self-promises are usable end-to-end (needed
for the demo).

- `routes/promises.js` now destructures `kind`/`visibility` from the
  request body and forwards them to `createPromise`. The required-fields
  check only demands a valid `stake` when `kind !== "self"`.
- `src/cli.js`'s `createPromise` gained `currency`, `kind`, `visibility`
  params, forwarded into `PromiseModel`.

## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

Closes PP-A7

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->


