### PR TITLE
docs: add project overview and contributors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Promise Protocol
 
+Promise Protocol is a full-stack web app built around a simple idea: promises should be trackable, and trust should be measurable. Users create promises to themselves or others, ranging from low-stakes personal commitments to higher-stakes staked agreements, and the app tracks outcomes over time to build a trust score based on what someone actually follows through on, not just what they say they'll do.
+
 ## Local Setup
 
 ### Frontend (React)
@@ -110,6 +112,14 @@ npm run format
 ```
 
 Prettier is integrated with ESLint via `eslint-config-prettier` to avoid conflicts. It is recommended to enable "Format on Save" in your editor using the Prettier extension.
+
+---
+
+## Contributors
+
+- Angela Fujihara ([A-Fujihara](https://github.com/A-Fujihara))
+- Mark Buster ([MarkBuster](https://github.com/MarkBuster))
+- Bade Habib ([JungDefiant](https://github.com/JungDefiant))
 
 ---
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Adds a project overview paragraph to the top of the README so the repo explains what Promise Protocol actually is (not just how to run it), and adds a Contributors section crediting the people who've built it.


## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [x] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [ ] I have written or updated tests for my changes
- [ ] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [x] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

N/A, README/documentation only, no UI changes.

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

This is a docs-only change, no functionality was added or changed, so the testing checklist items are marked N/A rather than checked, there's nothing to test. The Contributors list currently reflects commit history; if anyone thinks it's missing someone or should also credit non-code contributions, flag it here before merging.
