### PR TITLE
feat: add outcome logging endpoint for self-promises

### DIFF
--- a/server/__tests__/outcomes.test.js
+++ b/server/__tests__/outcomes.test.js
@@ -99,4 +99,10 @@ describe("GET /api/outcomes", () => {
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0]).toHaveProperty("promiseId", "prm_self_001");
   });
+
+  it("should return 400 if promiseId is missing", async () => {
+    const res = await request(app).get("/api/outcomes");
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
 });

--- a/server/__tests__/outcomes.test.js
+++ b/server/__tests__/outcomes.test.js
@@ -1,0 +1,102 @@
+const request = require("supertest");
+const app = require("../server");
+
+jest.mock("../src/Storage", () => ({
+  savePromise: jest.fn((promise) => promise),
+  getPromises: jest.fn(() => [
+    {
+      id: "prm_self_001",
+      promiserId: "user_001",
+      kind: "self",
+      visibility: "private",
+    },
+    {
+      id: "prm_assessed_001",
+      promiserId: "user_001",
+      kind: "assessed",
+      visibility: "public",
+    },
+  ]),
+  saveAssessment: jest.fn((assessment) => assessment),
+  getAssessments: jest.fn(() => []),
+  getAssessmentSummary: jest.fn(() => ({ kept: 0, broken: 0, total: 0 })),
+  saveOutcome: jest.fn((outcome) => outcome),
+  getOutcomes: jest.fn(() => [
+    {
+      id: "out_existing_001",
+      promiseId: "prm_self_001",
+      outcome: "kept",
+      note: null,
+      attachmentRef: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  ]),
+}));
+
+describe("POST /api/outcomes", () => {
+  it("should log an outcome against a self-promise and return 201", async () => {
+    const res = await request(app).post("/api/outcomes").send({
+      promiseId: "prm_self_001",
+      outcome: "kept",
+      note: "Went for a run this morning.",
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("id");
+    expect(res.body.promiseId).toBe("prm_self_001");
+    expect(res.body.outcome).toBe("kept");
+  });
+
+  it("should return 400 if promiseId is missing", async () => {
+    const res = await request(app).post("/api/outcomes").send({
+      outcome: "kept",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("should return 400 if outcome is missing", async () => {
+    const res = await request(app).post("/api/outcomes").send({
+      promiseId: "prm_self_001",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("should return 404 for a non-existent promise", async () => {
+    const res = await request(app).post("/api/outcomes").send({
+      promiseId: "prm_does_not_exist",
+      outcome: "kept",
+    });
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("should return 400 when logging against a non-self promise", async () => {
+    const res = await request(app).post("/api/outcomes").send({
+      promiseId: "prm_assessed_001",
+      outcome: "kept",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("should return 400 for an invalid outcome value", async () => {
+    const res = await request(app).post("/api/outcomes").send({
+      promiseId: "prm_self_001",
+      outcome: "not_a_real_outcome",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+});
+
+describe("GET /api/outcomes", () => {
+  it("should return outcomes for a given promiseId", async () => {
+    const res = await request(app)
+      .get("/api/outcomes")
+      .query({ promiseId: "prm_self_001" });
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty("promiseId", "prm_self_001");
+  });
+});

--- a/server/routes/outcomes.js
+++ b/server/routes/outcomes.js
@@ -29,7 +29,12 @@ router.post("/", (req, res) => {
 
 router.get("/", (req, res) => {
   const { promiseId } = req.query;
-  const outcomes = listOutcomes(promiseId ? { promiseId } : {});
+
+  if (!promiseId) {
+    return res.status(400).json({ error: "Missing required fields" });
+  }
+
+  const outcomes = listOutcomes({ promiseId });
   return res.status(200).json(outcomes || []);
 });
 

--- a/server/routes/outcomes.js
+++ b/server/routes/outcomes.js
@@ -1,0 +1,36 @@
+const express = require("express");
+const router = express.Router();
+const { logOutcome, listOutcomes, getPromiseById } = require("../src/cli");
+
+router.post("/", (req, res) => {
+  const { promiseId, outcome, note, attachmentRef } = req.body;
+
+  if (!promiseId || !outcome) {
+    return res.status(400).json({ error: "Missing required fields" });
+  }
+
+  const promise = getPromiseById(promiseId);
+  if (!promise) {
+    return res.status(404).json({ error: "Promise not found" });
+  }
+  if (promise.kind !== "self") {
+    return res.status(400).json({
+      error: "Outcomes can only be logged against self-promises",
+    });
+  }
+
+  try {
+    const outcomeRecord = logOutcome(promiseId, outcome, note, attachmentRef);
+    return res.status(201).json(outcomeRecord);
+  } catch (error) {
+    return res.status(400).json({ error: error.message });
+  }
+});
+
+router.get("/", (req, res) => {
+  const { promiseId } = req.query;
+  const outcomes = listOutcomes(promiseId ? { promiseId } : {});
+  return res.status(200).json(outcomes || []);
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,9 +1,10 @@
+const promisesRouter = require("./routes/promises");
+const assessmentsRouter = require("./routes/assessments");
+const outcomesRouter = require("./routes/outcomes");
+
 require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
-
-const promisesRouter = require("./routes/promises");
-const assessmentsRouter = require("./routes/assessments");
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -13,6 +14,7 @@ app.use(express.json());
 
 app.use("/api/promises", promisesRouter);
 app.use("/api/assessments", assessmentsRouter);
+app.use("/api/outcomes", outcomesRouter);
 
 // Only start listening if we are NOT running tests
 if (process.env.NODE_ENV !== 'test') {

--- a/server/src/cli.js
+++ b/server/src/cli.js
@@ -1,5 +1,6 @@
 const PromiseModel = require("../models/PromiseModel");
 const Assessment = require("./Assessment");
+const Outcome = require("./Outcome");
 const {
   savePromise,
   getPromises,
@@ -7,6 +8,8 @@ const {
   getAssessments,
   updatePromise,
   getAssessmentSummary,
+  saveOutcome,
+  getOutcomes,
 } = require("./Storage");
 
 // TODO (Tech Debt): Refactor assessment, merit, and ledger logic.
@@ -41,6 +44,16 @@ const createPromise = (
   savePromise(promise);
   console.log(`✓ Promise created: ${promise.id}`);
   return promise;
+};
+
+/**
+ * Looks up a single promise by id.
+ * @param {string} promiseId
+ * @returns {object|null} The matching promise, or null if not found.
+ */
+const getPromiseById = (promiseId) => {
+  const promises = getPromises();
+  return promises.find((p) => p.id === promiseId) || null;
 };
 
 const listPromises = (filters = {}) => {
@@ -118,9 +131,33 @@ const listAssessments = (filters = {}) => {
   return assessments;
 };
 
+/**
+ * Logs a self-reported outcome check-in against a self-promise.
+ * The Outcome model itself validates that `outcome` is a recognized state
+ * (see SelfTrust.VALID_OUTCOMES); this function does not re-validate it.
+ * @param {string} promiseId
+ * @param {string} outcome - One of SelfTrust.VALID_OUTCOMES.
+ * @param {string} [note]
+ * @param {string} [attachmentRef]
+ * @returns {Outcome} The created outcome record.
+ */
+const logOutcome = (promiseId, outcome, note, attachmentRef) => {
+  const outcomeRecord = new Outcome(promiseId, outcome, note, attachmentRef);
+  saveOutcome(outcomeRecord);
+  console.log(`✓ Outcome logged: ${outcomeRecord.id}`);
+  return outcomeRecord;
+};
+
+const listOutcomes = (filters = {}) => {
+  return getOutcomes(filters);
+};
+
 module.exports = {
   createPromise,
   listPromises,
+  getPromiseById,
   submitAssessment,
   listAssessments,
+  logOutcome,
+  listOutcomes,
 };


### PR DESCRIPTION
Closes #A3 (PP-A3)

## Summary

<!-- Briefly describe what this PR does and why -->

Adds the outcome-logging endpoint for self-promises — the second half of
the two-promise pattern. Priya can now POST a check-in against a
self-promise and see her logged history via GET.

- `server/routes/outcomes.js` (new): POST / validates promiseId and outcome
  are present, confirms the promise exists (404 if not) and is kind: "self"
  (400 if not), then logs it. GET /?promiseId=... returns outcomes for a
  promise.
- `server/src/cli.js`: added logOutcome, listOutcomes, and a
  getPromiseById lookup helper, following the existing createPromise
  pattern.
- `server/server.js`: wired the new router in alongside the existing two.

## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/74

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

Both dependencies (PP-A1's kind field, PP-A2's Outcome model + storage)
were already on main, so this is a straight wire-up — no changes to
PromiseModel, Outcome, or Storage. Non-existent promise returns 404,
wrong-kind promise returns 400 — the ticket's AC just said "4xx" for both,
so this splits them for clarity; flag if you'd rather they collapse to
one status code. 70/70 tests passing locally (8/8 suites).