### PR TITLE
PP-A4: add self-trust scoring endpoint

### DIFF
--- a/server/__tests__/promises.test.js
+++ b/server/__tests__/promises.test.js
@@ -1,5 +1,6 @@
 const request = require("supertest");
 const app = require("../server");
+const Storage = require("../src/Storage");
 
 jest.mock("../src/Storage", () => ({
   savePromise: jest.fn((promise) => promise),
@@ -7,6 +8,8 @@ jest.mock("../src/Storage", () => ({
   saveAssessment: jest.fn((assessment) => assessment),
   getAssessments: jest.fn(() => []),
   getAssessmentSummary: jest.fn(() => ({ kept: 0, broken: 0, total: 0 })),
+  saveOutcome: jest.fn((outcome) => outcome),
+  getOutcomes: jest.fn(() => []),
 }));
 
 describe("POST /api/promises", () => {
@@ -145,5 +148,87 @@ describe("GET /api/promises", () => {
     const res = await request(app).get("/api/promises");
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
+  });
+});
+
+describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
+  afterEach(() => {
+    Storage.getPromises.mockReset().mockReturnValue([]);
+    Storage.getOutcomes.mockReset().mockReturnValue([]);
+  });
+
+  it("should return { score: 50, count: 0 } for a self-promise with no outcomes", async () => {
+    Storage.getPromises.mockReturnValue([
+      { id: "prm_self_001", promiserId: "priya_001", kind: "self" },
+    ]);
+    Storage.getOutcomes.mockReturnValue([]);
+
+    const res = await request(app).get(
+      "/api/promises/prm_self_001/self-trust",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ score: 50, count: 0 });
+  });
+
+  it("should score a forgotten outcome far lower than a failed_but_noticed outcome", async () => {
+    Storage.getPromises.mockReturnValue([
+      { id: "prm_self_001", promiserId: "priya_001", kind: "self" },
+      { id: "prm_self_002", promiserId: "priya_001", kind: "self" },
+    ]);
+
+    Storage.getOutcomes.mockReturnValueOnce([
+      { promiseId: "prm_self_001", outcome: "forgotten" },
+    ]);
+    const forgottenRes = await request(app).get(
+      "/api/promises/prm_self_001/self-trust",
+    );
+
+    Storage.getOutcomes.mockReturnValueOnce([
+      { promiseId: "prm_self_002", outcome: "failed_but_noticed" },
+    ]);
+    const noticedRes = await request(app).get(
+      "/api/promises/prm_self_002/self-trust",
+    );
+
+    expect(forgottenRes.body.score).toBeLessThan(noticedRes.body.score);
+  });
+
+  it("should return a score matching a hand-computation from logged outcomes", async () => {
+    Storage.getPromises.mockReturnValue([
+      { id: "prm_self_001", promiserId: "priya_001", kind: "self" },
+    ]);
+    // kept (1.0), partially_kept (0.7) -> average 0.85 -> 85
+    Storage.getOutcomes.mockReturnValue([
+      { promiseId: "prm_self_001", outcome: "kept" },
+      { promiseId: "prm_self_001", outcome: "partially_kept" },
+    ]);
+
+    const res = await request(app).get(
+      "/api/promises/prm_self_001/self-trust",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ score: 85, count: 2 });
+  });
+
+  it("should return 404 for a non-existent promise", async () => {
+    Storage.getPromises.mockReturnValue([]);
+
+    const res = await request(app).get(
+      "/api/promises/prm_does_not_exist/self-trust",
+    );
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("should return 400 when the promise is not a self-promise", async () => {
+    Storage.getPromises.mockReturnValue([
+      { id: "prm_assessed_001", promiserId: "user_001", kind: "assessed" },
+    ]);
+
+    const res = await request(app).get(
+      "/api/promises/prm_assessed_001/self-trust",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
   });
 });

--- a/server/__tests__/promises.test.js
+++ b/server/__tests__/promises.test.js
@@ -155,6 +155,8 @@ describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
   afterEach(() => {
     Storage.getPromises.mockReset().mockReturnValue([]);
     Storage.getOutcomes.mockReset().mockReturnValue([]);
+    Storage.savePromise.mockReset().mockImplementation((promise) => promise);
+    Storage.saveOutcome.mockReset().mockImplementation((outcome) => outcome);
   });
 
   it("should return { score: 50, count: 0 } for a self-promise with no outcomes", async () => {
@@ -193,18 +195,56 @@ describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
     expect(forgottenRes.body.score).toBeLessThan(noticedRes.body.score);
   });
 
-  it("should return a score matching a hand-computation from logged outcomes", async () => {
-    Storage.getPromises.mockReturnValue([
-      { id: "prm_self_001", promiserId: "priya_001", kind: "self" },
-    ]);
+  it("should walk the full flow (create self-promise -> log outcomes -> self-trust score) and match a hand-computation", async () => {
+    // In-memory backing arrays so savePromise/getPromises and
+    // saveOutcome/getOutcomes behave like real storage for this test,
+    // instead of stubbing getOutcomes directly. This drives the request
+    // through POST /api/promises and POST /api/outcomes for real, so the
+    // test actually proves the two routes agree on how a promise's
+    // outcomes are looked up, not just that computeSelfTrust can do math.
+    const promises = [];
+    const outcomes = [];
+
+    Storage.savePromise.mockImplementation((promise) => {
+      promises.push(promise);
+      return promise;
+    });
+    Storage.getPromises.mockImplementation(() => promises);
+    Storage.saveOutcome.mockImplementation((outcome) => {
+      outcomes.push(outcome);
+      return outcome;
+    });
+    Storage.getOutcomes.mockImplementation(({ promiseId } = {}) =>
+      outcomes.filter((o) => o.promiseId === promiseId),
+    );
+
+    const createRes = await request(app)
+      .post("/api/promises")
+      .send({
+        promiserId: "priya_001",
+        promiseeScope: "self",
+        domain: "wellness",
+        objective: "Meditate for 10 minutes every morning",
+        days: 14,
+        successCriteria: "Logged a session on at least 12 of 14 days",
+        kind: "self",
+      });
+    expect(createRes.status).toBe(201);
+    const promiseId = createRes.body.id;
+
     // kept (1.0), partially_kept (0.7) -> average 0.85 -> 85
-    Storage.getOutcomes.mockReturnValue([
-      { promiseId: "prm_self_001", outcome: "kept" },
-      { promiseId: "prm_self_001", outcome: "partially_kept" },
-    ]);
+    const outcomeOneRes = await request(app)
+      .post("/api/outcomes")
+      .send({ promiseId, outcome: "kept" });
+    expect(outcomeOneRes.status).toBe(201);
+
+    const outcomeTwoRes = await request(app)
+      .post("/api/outcomes")
+      .send({ promiseId, outcome: "partially_kept" });
+    expect(outcomeTwoRes.status).toBe(201);
 
     const res = await request(app).get(
-      "/api/promises/prm_self_001/self-trust",
+      `/api/promises/${promiseId}/self-trust`,
     );
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ score: 85, count: 2 });

--- a/server/routes/promises.js
+++ b/server/routes/promises.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
-const { createPromise, listPromises } = require("../src/cli");
+const { createPromise, listPromises, getPromiseById, listOutcomes } = require("../src/cli");
+const { computeSelfTrust } = require("../src/SelfTrust");
 
 router.post("/", (req, res) => {
   const {
@@ -52,6 +53,27 @@ router.post("/", (req, res) => {
 router.get("/", (req, res) => {
   const promises = listPromises();
   return res.status(200).json(promises || []);
+});
+
+// PP-A4: self-trust score for a self-promise. Never stored — recomputed on
+// every request straight from the logged outcomes via SelfTrust.computeSelfTrust,
+// so the number can never go stale.
+router.get("/:id/self-trust", (req, res) => {
+  const { id } = req.params;
+
+  const promise = getPromiseById(id);
+  if (!promise) {
+    return res.status(404).json({ error: "Promise not found" });
+  }
+  if (promise.kind !== "self") {
+    return res.status(400).json({
+      error: "Self-trust score is only available for self-promises",
+    });
+  }
+
+  const outcomes = listOutcomes({ promiseId: id });
+  const { score, count } = computeSelfTrust(outcomes);
+  return res.status(200).json({ score, count });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

Adds GET /api/promises/:id/self-trust, which exposes a self-promise's self-trust score. The score is never stored, it's recomputed on every request from the promise's logged outcomes via the existing SelfTrust.computeSelfTrust, so it can't drift out of sync with the outcome history. This closes the Sprint A loop: the self-trust thesis is now provable end-to-end via the API (create self-promise → log outcomes → GET score).

## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/75

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

N/A, backend-only endpoint.

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

No new storage or model code needed. getPromiseById, listOutcomes, and SelfTrust.computeSelfTrust all already existed and did exactly what the ticket needed; this PR is wiring.
Mirrors the guard pattern already used in outcomes.js: 404 if the promise doesn't exist, 400 if it's not a self-promise (kind !== "self"). The ticket doesn't explicitly spell out non-self-promise behavior, so this was an inferred decision for consistency, not something stated in the acceptance criteria. Flagging in case reviewer wants it handled differently.
Test coverage added in promises.test.js under a new GET /api/promises/:id/self-trust (PP-A4) describe block: no-outcomes default (score 50, count 0), forgotten vs. failed_but_noticed honesty distinction, hand-computed score check, 404 for missing promise, 400 for non-self promise.
Full server suite: 8 suites / 76 tests, all passing.
