### PR TITLE
feat: add self-trust score display component (PP-A5)

### DIFF
--- a/src/components/SelfTrustScore.jsx
+++ b/src/components/SelfTrustScore.jsx
@@ -1,0 +1,39 @@
+import styles from './SelfTrustScore.module.css';
+
+// Range thresholds for the low/mid/high visual treatment.
+// score is 0-100; anything below LOW_MAX reads as low, at/above HIGH_MIN reads as high.
+const LOW_MAX = 40;
+const HIGH_MIN = 70;
+
+function getRange(score) {
+  if (score < LOW_MAX) return 'low';
+  if (score >= HIGH_MIN) return 'high';
+  return 'mid';
+}
+
+const RANGE_LABEL = {
+  low: 'Needs attention',
+  mid: 'Building',
+  high: 'Strong',
+};
+
+export default function SelfTrustScore({ score = 50, count = 0 }) {
+  const range = getRange(score);
+
+  return (
+    <div className={styles.container} data-range={range}>
+      <div className={styles.scoreRow}>
+        <span className={styles.score}>{score}</span>
+        <span className={styles.scoreMax}>/100</span>
+      </div>
+      <div className={styles.label}>Self-Trust Score</div>
+      <div className={styles.meta}>
+        <span className={styles.rangeTag}>{RANGE_LABEL[range]}</span>
+        <span className={styles.divider}>·</span>
+        <span className={styles.count}>
+          {count} check-in{count === 1 ? '' : 's'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SelfTrustScore.module.css
+++ b/src/components/SelfTrustScore.module.css
@@ -1,0 +1,87 @@
+.container {
+  background: var(--pp-surface);
+  border: 1px solid var(--pp-border);
+  border-radius: var(--pp-border-radius);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+/* ─── Score ───────────────────────────────────────────────────────── */
+.scoreRow {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.score {
+  font-size: 40px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--pp-text-primary);
+  transition: color 0.2s ease;
+}
+
+.scoreMax {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--pp-text-muted);
+}
+
+/* ─── Label ───────────────────────────────────────────────────────── */
+.label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--pp-text-secondary);
+}
+
+/* ─── Meta row ────────────────────────────────────────────────────── */
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 12px;
+}
+
+.rangeTag {
+  font-weight: 600;
+  color: var(--pp-text-secondary);
+}
+
+.divider {
+  color: var(--pp-text-muted);
+}
+
+.count {
+  color: var(--pp-text-muted);
+}
+
+/* ─── Range-driven color, set via data-range on the container ──────── */
+.container[data-range='low'] .score {
+  color: var(--pp-red);
+}
+
+.container[data-range='low'] .rangeTag {
+  color: var(--pp-red);
+}
+
+.container[data-range='mid'] .score {
+  color: var(--pp-amber);
+}
+
+.container[data-range='mid'] .rangeTag {
+  color: var(--pp-amber);
+}
+
+.container[data-range='high'] .score {
+  color: var(--pp-green);
+}
+
+.container[data-range='high'] .rangeTag {
+  color: var(--pp-green);
+}

--- a/src/components/SelfTrustScore.test.jsx
+++ b/src/components/SelfTrustScore.test.jsx
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SelfTrustScore from './SelfTrustScore';
+
+describe('SelfTrustScore', () => {
+  test('renders fresh state: score 50, count 0', () => {
+    render(<SelfTrustScore score={50} count={0} />);
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('/100')).toBeInTheDocument();
+    expect(screen.getByText('Self-Trust Score')).toBeInTheDocument();
+    expect(screen.getByText('0 check-ins')).toBeInTheDocument();
+  });
+
+  test('renders low score with low range styling', () => {
+    render(<SelfTrustScore score={22} count={4} />);
+    expect(screen.getByText('22')).toBeInTheDocument();
+    expect(screen.getByText('4 check-ins')).toBeInTheDocument();
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    const container = screen.getByText('22').closest('div[data-range]');
+    expect(container).toHaveAttribute('data-range', 'low');
+  });
+
+  test('renders high score with high range styling', () => {
+    render(<SelfTrustScore score={88} count={17} />);
+    expect(screen.getByText('88')).toBeInTheDocument();
+    expect(screen.getByText('17 check-ins')).toBeInTheDocument();
+    expect(screen.getByText('Strong')).toBeInTheDocument();
+    const container = screen.getByText('88').closest('div[data-range]');
+    expect(container).toHaveAttribute('data-range', 'high');
+  });
+
+  test('mid-range score renders "Building" tag', () => {
+    render(<SelfTrustScore score={55} count={2} />);
+    expect(screen.getByText('Building')).toBeInTheDocument();
+    const container = screen.getByText('55').closest('div[data-range]');
+    expect(container).toHaveAttribute('data-range', 'mid');
+  });
+
+  test('singular check-in label when count is 1', () => {
+    render(<SelfTrustScore score={60} count={1} />);
+    expect(screen.getByText('1 check-in')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why -->

## Related Issue

<!-- Link the backlog item this PR addresses -->

Adds a pure presentational SelfTrustScore component that displays a 0-100
score, label, and check-in count. Built against mock props only, per the
ticket — no endpoint wiring. Color range (low/mid/high) is driven entirely
by existing tokens.css variables via a data-range attribute, no new
hardcoded colors.

Closes #

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/76

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

Thresholds (score < 40 = low, 40-69 = mid, ≥70 = high) weren't specified
in the ticket, so I picked reasonable cutoffs — flag if you want them
adjusted. Animation was explicitly deferred per the ticket ("will
eventually animate"), so this is static for now.
