### PR TITLE
feat(PP-A6): enforce visibility on private self-promises

### DIFF
--- a/server/__tests__/outcomes.test.js
+++ b/server/__tests__/outcomes.test.js
@@ -39,6 +39,7 @@ describe("POST /api/outcomes", () => {
       promiseId: "prm_self_001",
       outcome: "kept",
       note: "Went for a run this morning.",
+      userId: "user_001",
     });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty("id");
@@ -57,6 +58,7 @@ describe("POST /api/outcomes", () => {
   it("should return 400 if outcome is missing", async () => {
     const res = await request(app).post("/api/outcomes").send({
       promiseId: "prm_self_001",
+      userId: "user_001",
     });
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty("error");
@@ -66,6 +68,7 @@ describe("POST /api/outcomes", () => {
     const res = await request(app).post("/api/outcomes").send({
       promiseId: "prm_does_not_exist",
       outcome: "kept",
+      userId: "user_001",
     });
     expect(res.status).toBe(404);
     expect(res.body).toHaveProperty("error");
@@ -84,9 +87,30 @@ describe("POST /api/outcomes", () => {
     const res = await request(app).post("/api/outcomes").send({
       promiseId: "prm_self_001",
       outcome: "not_a_real_outcome",
+      userId: "user_001",
     });
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty("error");
+  });
+
+  describe("Private self-promise access enforcement (PP-A6)", () => {
+    it("returns 404 when a different user id tries to log against a private self-promise", async () => {
+      const res = await request(app).post("/api/outcomes").send({
+        promiseId: "prm_self_001",
+        outcome: "kept",
+        userId: "mallory_002",
+      });
+      expect(res.status).toBe(404);
+      expect(res.body).toHaveProperty("error");
+    });
+
+    it("returns 404 when no userId is supplied for a private self-promise", async () => {
+      const res = await request(app).post("/api/outcomes").send({
+        promiseId: "prm_self_001",
+        outcome: "kept",
+      });
+      expect(res.status).toBe(404);
+    });
   });
 });
 

--- a/server/__tests__/outcomes.test.js
+++ b/server/__tests__/outcomes.test.js
@@ -94,7 +94,7 @@ describe("GET /api/outcomes", () => {
   it("should return outcomes for a given promiseId", async () => {
     const res = await request(app)
       .get("/api/outcomes")
-      .query({ promiseId: "prm_self_001" });
+      .query({ promiseId: "prm_self_001", userId: "user_001" });
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0]).toHaveProperty("promiseId", "prm_self_001");
@@ -104,5 +104,32 @@ describe("GET /api/outcomes", () => {
     const res = await request(app).get("/api/outcomes");
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty("error");
+  });
+
+  describe("Private self-promise access enforcement (PP-A6)", () => {
+    it("returns 404 for a private self-promise's outcomes to a different user id", async () => {
+      const res = await request(app)
+        .get("/api/outcomes")
+        .query({ promiseId: "prm_self_001", userId: "mallory_002" });
+      expect(res.status).toBe(404);
+      expect(res.body).not.toEqual(
+        expect.arrayContaining([expect.anything()]),
+      );
+    });
+
+    it("returns 404 when no userId is supplied for a private self-promise", async () => {
+      const res = await request(app)
+        .get("/api/outcomes")
+        .query({ promiseId: "prm_self_001" });
+      expect(res.status).toBe(404);
+    });
+
+    it("still returns outcomes for a public/assessed promise without a userId (regression)", async () => {
+      const res = await request(app)
+        .get("/api/outcomes")
+        .query({ promiseId: "prm_assessed_001" });
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
   });
 });

--- a/server/__tests__/promises.test.js
+++ b/server/__tests__/promises.test.js
@@ -161,36 +161,51 @@ describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
 
   it("should return { score: 50, count: 0 } for a self-promise with no outcomes", async () => {
     Storage.getPromises.mockReturnValue([
-      { id: "prm_self_001", promiserId: "priya_001", kind: "self" },
+      {
+        id: "prm_self_001",
+        promiserId: "priya_001",
+        kind: "self",
+        visibility: "private",
+      },
     ]);
     Storage.getOutcomes.mockReturnValue([]);
 
-    const res = await request(app).get(
-      "/api/promises/prm_self_001/self-trust",
-    );
+    const res = await request(app)
+      .get("/api/promises/prm_self_001/self-trust")
+      .query({ userId: "priya_001" });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ score: 50, count: 0 });
   });
 
   it("should score a forgotten outcome far lower than a failed_but_noticed outcome", async () => {
     Storage.getPromises.mockReturnValue([
-      { id: "prm_self_001", promiserId: "priya_001", kind: "self" },
-      { id: "prm_self_002", promiserId: "priya_001", kind: "self" },
+      {
+        id: "prm_self_001",
+        promiserId: "priya_001",
+        kind: "self",
+        visibility: "private",
+      },
+      {
+        id: "prm_self_002",
+        promiserId: "priya_001",
+        kind: "self",
+        visibility: "private",
+      },
     ]);
 
     Storage.getOutcomes.mockReturnValueOnce([
       { promiseId: "prm_self_001", outcome: "forgotten" },
     ]);
-    const forgottenRes = await request(app).get(
-      "/api/promises/prm_self_001/self-trust",
-    );
+    const forgottenRes = await request(app)
+      .get("/api/promises/prm_self_001/self-trust")
+      .query({ userId: "priya_001" });
 
     Storage.getOutcomes.mockReturnValueOnce([
       { promiseId: "prm_self_002", outcome: "failed_but_noticed" },
     ]);
-    const noticedRes = await request(app).get(
-      "/api/promises/prm_self_002/self-trust",
-    );
+    const noticedRes = await request(app)
+      .get("/api/promises/prm_self_002/self-trust")
+      .query({ userId: "priya_001" });
 
     expect(forgottenRes.body.score).toBeLessThan(noticedRes.body.score);
   });
@@ -243,9 +258,9 @@ describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
       .send({ promiseId, outcome: "partially_kept" });
     expect(outcomeTwoRes.status).toBe(201);
 
-    const res = await request(app).get(
-      `/api/promises/${promiseId}/self-trust`,
-    );
+    const res = await request(app)
+      .get(`/api/promises/${promiseId}/self-trust`)
+      .query({ userId: "priya_001" });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ score: 85, count: 2 });
   });
@@ -270,5 +285,63 @@ describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
     );
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty("error");
+  });
+});
+
+describe("Private self-promise access enforcement (PP-A6)", () => {
+  const owner = "priya_001";
+  const otherUser = "mallory_002";
+
+  beforeEach(() => {
+    Storage.getPromises.mockReset().mockReturnValue([
+      {
+        id: "prm_self_001",
+        promiserId: owner,
+        kind: "self",
+        visibility: "private",
+      },
+    ]);
+    Storage.getOutcomes.mockReset().mockReturnValue([]);
+  });
+
+  describe("GET /api/promises/:id", () => {
+    it("returns the promise to its owner", async () => {
+      const res = await request(app)
+        .get("/api/promises/prm_self_001")
+        .query({ userId: owner });
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe("prm_self_001");
+    });
+
+    it("returns 404 to a different user id, not the promise data", async () => {
+      const res = await request(app)
+        .get("/api/promises/prm_self_001")
+        .query({ userId: otherUser });
+      expect(res.status).toBe(404);
+      expect(res.body).not.toHaveProperty("promiserId");
+    });
+
+    it("returns 404 when no userId is supplied at all", async () => {
+      const res = await request(app).get("/api/promises/prm_self_001");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/promises/:id/self-trust", () => {
+    it("returns the score to its owner", async () => {
+      const res = await request(app)
+        .get("/api/promises/prm_self_001/self-trust")
+        .query({ userId: owner });
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("score");
+    });
+
+    it("returns 404 to a different user id, not the score", async () => {
+      const res = await request(app)
+        .get("/api/promises/prm_self_001/self-trust")
+        .query({ userId: otherUser });
+      expect(res.status).toBe(404);
+      expect(res.body).not.toHaveProperty("score");
+    });
   });
 });

--- a/server/__tests__/promises.test.js
+++ b/server/__tests__/promises.test.js
@@ -149,6 +149,50 @@ describe("GET /api/promises", () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
   });
+
+  describe("Private self-promise access enforcement (PP-A6)", () => {
+    it("excludes another user's private self-promise from the list", async () => {
+      Storage.getPromises.mockReturnValue([
+        {
+          id: "prm_public_001",
+          promiserId: "user_001",
+          kind: "assessed",
+          visibility: "public",
+        },
+        {
+          id: "prm_self_001",
+          promiserId: "priya_001",
+          kind: "self",
+          visibility: "private",
+        },
+      ]);
+
+      const res = await request(app)
+        .get("/api/promises")
+        .query({ userId: "mallory_002" });
+      expect(res.status).toBe(200);
+      const ids = res.body.map((p) => p.id);
+      expect(ids).toContain("prm_public_001");
+      expect(ids).not.toContain("prm_self_001");
+    });
+
+    it("includes the owner's own private self-promise in their list", async () => {
+      Storage.getPromises.mockReturnValue([
+        {
+          id: "prm_self_001",
+          promiserId: "priya_001",
+          kind: "self",
+          visibility: "private",
+        },
+      ]);
+
+      const res = await request(app)
+        .get("/api/promises")
+        .query({ userId: "priya_001" });
+      expect(res.status).toBe(200);
+      expect(res.body.map((p) => p.id)).toContain("prm_self_001");
+    });
+  });
 });
 
 describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
@@ -250,12 +294,12 @@ describe("GET /api/promises/:id/self-trust (PP-A4)", () => {
     // kept (1.0), partially_kept (0.7) -> average 0.85 -> 85
     const outcomeOneRes = await request(app)
       .post("/api/outcomes")
-      .send({ promiseId, outcome: "kept" });
+      .send({ promiseId, outcome: "kept", userId: "priya_001" });
     expect(outcomeOneRes.status).toBe(201);
 
     const outcomeTwoRes = await request(app)
       .post("/api/outcomes")
-      .send({ promiseId, outcome: "partially_kept" });
+      .send({ promiseId, outcome: "partially_kept", userId: "priya_001" });
     expect(outcomeTwoRes.status).toBe(201);
 
     const res = await request(app)

--- a/server/routes/outcomes.js
+++ b/server/routes/outcomes.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { logOutcome, listOutcomes, getPromiseById } = require("../src/cli");
+const { canAccessPromise } = require("../src/accessControl");
 
 router.post("/", (req, res) => {
   const { promiseId, outcome, note, attachmentRef } = req.body;
@@ -27,11 +28,18 @@ router.post("/", (req, res) => {
   }
 });
 
+// PP-A6: outcomes for a private self-promise are only visible to its owner,
+// same check as GET /api/promises/:id.
 router.get("/", (req, res) => {
-  const { promiseId } = req.query;
+  const { promiseId, userId } = req.query;
 
   if (!promiseId) {
     return res.status(400).json({ error: "Missing required fields" });
+  }
+
+  const promise = getPromiseById(promiseId);
+  if (!canAccessPromise(promise, userId)) {
+    return res.status(404).json({ error: "Promise not found" });
   }
 
   const outcomes = listOutcomes({ promiseId });

--- a/server/routes/outcomes.js
+++ b/server/routes/outcomes.js
@@ -4,14 +4,19 @@ const { logOutcome, listOutcomes, getPromiseById } = require("../src/cli");
 const { canAccessPromise } = require("../src/accessControl");
 
 router.post("/", (req, res) => {
-  const { promiseId, outcome, note, attachmentRef } = req.body;
+  const { promiseId, outcome, note, attachmentRef, userId } = req.body;
 
   if (!promiseId || !outcome) {
     return res.status(400).json({ error: "Missing required fields" });
   }
 
   const promise = getPromiseById(promiseId);
-  if (!promise) {
+  // PP-A6: a private self-promise can only have outcomes logged by its
+  // owner. Checked before the not-found/kind checks below so a non-owner
+  // gets the same 404 whether the promise is private or doesn't exist,
+  // and can't use this endpoint to log against (or probe the existence
+  // of) someone else's private promise.
+  if (!canAccessPromise(promise, userId)) {
     return res.status(404).json({ error: "Promise not found" });
   }
   if (promise.kind !== "self") {

--- a/server/routes/promises.js
+++ b/server/routes/promises.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const { createPromise, listPromises, getPromiseById, listOutcomes } = require("../src/cli");
 const { computeSelfTrust } = require("../src/SelfTrust");
+const { canAccessPromise } = require("../src/accessControl");
 
 router.post("/", (req, res) => {
   const {
@@ -55,14 +56,32 @@ router.get("/", (req, res) => {
   return res.status(200).json(promises || []);
 });
 
+// PP-A6: fetch a single promise by id. A private promise is only visible to
+// its owner - see accessControl.canAccessPromise. Mismatch and not-found
+// both return 404 so a private promise's existence isn't revealed either way.
+router.get("/:id", (req, res) => {
+  const { id } = req.params;
+  const { userId } = req.query;
+
+  const promise = getPromiseById(id);
+  if (!canAccessPromise(promise, userId)) {
+    return res.status(404).json({ error: "Promise not found" });
+  }
+
+  return res.status(200).json(promise);
+});
+
 // PP-A4: self-trust score for a self-promise. Never stored — recomputed on
 // every request straight from the logged outcomes via SelfTrust.computeSelfTrust,
 // so the number can never go stale.
+// PP-A6: gated by the same ownership check as GET /:id, since this leaks the
+// same private data in a different shape.
 router.get("/:id/self-trust", (req, res) => {
   const { id } = req.params;
+  const { userId } = req.query;
 
   const promise = getPromiseById(id);
-  if (!promise) {
+  if (!canAccessPromise(promise, userId)) {
     return res.status(404).json({ error: "Promise not found" });
   }
   if (promise.kind !== "self") {

--- a/server/routes/promises.js
+++ b/server/routes/promises.js
@@ -51,9 +51,13 @@ router.post("/", (req, res) => {
   }
 });
 
+// PP-A6: the list endpoint returns every promise, so it must filter out
+// private ones that aren't the requester's own, same check as GET /:id.
 router.get("/", (req, res) => {
-  const promises = listPromises();
-  return res.status(200).json(promises || []);
+  const { userId } = req.query;
+  const promises = listPromises() || [];
+  const visible = promises.filter((p) => canAccessPromise(p, userId));
+  return res.status(200).json(visible);
 });
 
 // PP-A6: fetch a single promise by id. A private promise is only visible to

--- a/server/src/accessControl.js
+++ b/server/src/accessControl.js
@@ -1,0 +1,27 @@
+/**
+ * PP-A6: Single choke point for private-promise ownership checks.
+ *
+ * The `visibility` field on a promise (PP-A1) was stored but never enforced -
+ * anyone could fetch a private self-promise, its outcomes, or its self-trust
+ * score by id. This is the one place that decides whether a requesting user
+ * is allowed to see a given promise's data.
+ *
+ * This is a deliberate stand-in for real auth. Once Epic 6 (auth) and RLS
+ * land, this function (and the requestingUserId plumbing that feeds it)
+ * gets replaced, not this call site's callers.
+ *
+ * @param {object|null} promise
+ * @param {string} requestingUserId
+ * @returns {boolean} true if the requesting user may access this promise.
+ */
+const canAccessPromise = (promise, requestingUserId) => {
+  if (!promise) {
+    return false;
+  }
+  if (promise.visibility !== "private") {
+    return true;
+  }
+  return promise.promiserId === requestingUserId;
+};
+
+module.exports = { canAccessPromise };


### PR DESCRIPTION
Add canAccessPromise ownership check (server/src/accessControl.js) and apply it to GET /api/promises/:id, GET /api/promises/:id/self-trust, and GET /api/outcomes. A private promise now 404s for any requester whose userId doesn't match the owner, same response as not-found so existence isn't leaked either way.

Adds GET /api/promises/:id, which didn't exist yet but is required to prove a private promise itself is unreachable per the acceptance criteria.

Tests proven against an explicit second mock user id (mallory_002), not just dev_user_001, plus regression coverage for public/assessed promises with no userId supplied.

## Summary

<!-- Briefly describe what this PR does and why -->

Adds real enforcement of the `visibility` field on self-promises. Previously
`visibility: "private"` was stored but never checked, any requester could
fetch a private self-promise, its outcomes, or its self-trust score by id.
Adds a single ownership check (`accessControl.canAccessPromise`) and applies
it to every GET endpoint that returns that data.

## Related Issue

<!-- Link the backlog item this PR addresses -->

Closes #

https://github.com/A-Fujihara/PromiseProtocol_WebApp/issues/91

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / setup
- [ ] Docs

## Checklist

- [x] My code follows the branch naming convention (`type/PP-xxx-short-description`)
- [x] My commits follow the Conventional Commits format
- [x] I have written or updated tests for my changes
- [x] All tests pass locally
- [ ] I have tested this manually in the browser
- [x] I have not committed any `.env` files or secrets
- [ ] I have updated relevant documentation if needed

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings for any UI changes -->

N/A, backend-only change.

## Notes for Reviewer

<!-- Anything the reviewer should know before reviewing -->

- `GET /api/promises/:id` is new, it didn't exist before this ticket, added
  because the AC requires a private promise itself to be unreachable, not
  just its outcomes/score.
- Ownership is currently proven via a plain `?userId=` query param, no real
  auth exists yet. This is a known stub, flagged for Epic 6 (auth) to replace.
- 404 (not 403) is used for both "not found" and "found but not yours" on
  purpose, so a private promise's existence isn't revealed by the status code.
